### PR TITLE
ZAPI-660 Requests to /vms hang forever which have a "fields" param and match no VMs

### DIFF
--- a/lib/endpoints/vms.js
+++ b/lib/endpoints/vms.js
@@ -64,7 +64,9 @@ function renderVms(req, res, next) {
 
     // Take any vm to get all its default rendered fields
     var aVm = (req.vms ? req.vms[0] : req.vm);
-    var vmFields = Object.keys(aVm);
+    // If we have an empty vms array though, just use an empty list
+    // (we won't have anything to iterate over anyway)
+    var vmFields = (typeof(aVm) === 'object') ? Object.keys(aVm) : [];
 
     // See if '*' was passed and remove duplicates
     for (var i = 0; i < fieldsParam.length; i++) {

--- a/test/vms.test.js
+++ b/test/vms.test.js
@@ -24,6 +24,7 @@ var muuid;
 var newUuid;
 var jobLocation;
 var vmLocation;
+var vmCount;
 var pkgId;
 
 var IMAGE = 'fd2cc906-8938-11e3-beab-4359c665ac99';
@@ -375,6 +376,53 @@ exports.head_vms_ok = function (t) {
         t.equal(res.statusCode, 200);
         common.checkHeaders(t, res.headers);
         t.ok(res.headers['x-joyent-resource-count']);
+        vmCount = res.headers['x-joyent-resource-count'];
+        t.done();
+    });
+};
+
+
+exports.offset_vms_ok = function(t) {
+    var path = '/vms?ram=' + 128 + '&owner_uuid=' + CUSTOMER + '&offset=2';
+
+    client.get(path, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        common.checkHeaders(t, res.headers);
+        t.ok(res.headers['x-joyent-resource-count']);
+        t.ok(body);
+        t.ok(Array.isArray(body));
+        t.equal(body.length, vmCount - 2);
+        t.done();
+    });
+};
+
+
+exports.offset_vms_at_end = function(t) {
+    var path = '/vms?ram=' + 128 + '&owner_uuid=' + CUSTOMER + '&offset=' + vmCount;
+
+    client.get(path, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        common.checkHeaders(t, res.headers);
+        t.ok(body);
+        t.ok(Array.isArray(body));
+        t.equal(body.length, 0);
+        t.done();
+    });
+};
+
+
+exports.offset_vms_beyond = function(t) {
+    var path = '/vms?ram=' + 128 + '&owner_uuid=' + CUSTOMER + '&offset=' + vmCount + 5;
+
+    client.get(path, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        common.checkHeaders(t, res.headers);
+        t.ok(body);
+        t.ok(Array.isArray(body));
+        t.equal(body.length, 0);
         t.done();
     });
 };


### PR DESCRIPTION
On any "list VMs" request that asks for a "fields" limit, if the query returns no results, we currently hang forever.

I first observed this when asking for an offset >= # of VMs. In this case, the req.vms array is empty. Currently we call Object.keys() on req.vms[0] in this case, which spits an error (since vms[0] is undefined). What we want to do is just return [].

Example of the error message in the vmapi logs:
```
[2015-06-11T01:19:01.505Z]  INFO: vmapi/api/33158 on 836d01b7-ff64-4717-958d-2bbd0cae17c6:  (req_id=d7a46a50-0fd7-11e5-b667-e3e634d86ba9)
    TypeError: Object.keys called on non-object
        at Function.keys (native)
        at Server.renderVms (/opt/smartdc/vmapi/lib/endpoints/vms.js:66:27)
        at next (/opt/smartdc/vmapi/node_modules/restify/lib/server.js:731:30)
        at f (/opt/smartdc/vmapi/node_modules/restify/node_modules/once/once.js:16:25)
        at /opt/smartdc/vmapi/lib/endpoints/vms.js:219:20
        at EventEmitter.<anonymous> (/opt/smartdc/vmapi/lib/apis/moray.js:522:20)
        at EventEmitter.g (events.js:180:16)
        at EventEmitter.emit (events.js:92:17)
        at EventEmitter.<anonymous> (/opt/smartdc/vmapi/node_modules/moray/lib/objects.js:197:13)
        at EventEmitter.g (events.js:180:16)
    --
    url: /vms?state=active&fields=uuid%2Cstate%2Cdestroyed%2Calias%2Cowner_uuid%2Cnics%2Cserver_uuid&offset=799&limit=799
    --
    params: {
      "state": "active",
      "fields": "uuid,state,destroyed,alias,owner_uuid,nics,server_uuid",
      "offset": "799",
      "limit": "799"
    }
```

I've attempted to add some tests in `vms.test.js` to cover this case, but I can't quite figure out how the ordering of tests is meant to work in there (they seem to just be set as keys on the `exports` object, which shouldn't have any ordering guarantee? but they assume ordering by re-using variables like `vmLocation` between tests...). Hopefully they work.

This has also been reported on IRC by ep1a in #smartos, on a request with no limit/offset parameters:

```
$ sdc-vmapi /vms?fields=nics&query=(alias%3Ddoesnotexist)
(hangs forever)
```