### PR TITLE
Enable snapshots for LX brand zones, clean up error messages

### DIFF
--- a/lib/endpoints/vms.js
+++ b/lib/endpoints/vms.js
@@ -917,10 +917,21 @@ function createSnapshot(req, res, next) {
     req.log.trace({ vm_uuid: req.params.uuid }, 'CreateSnapshot start');
     var vm = req.vm;
 
-    if ((['joyent', 'joyent-minimal', 'sngl'].indexOf(vm.brand) === -1) ||
-        (vm.datasets && vm.datasets.length && vm.datasets.length > 0)) {
+    if (['joyent', 'joyent-minimal', 'sngl', 'lx'].indexOf(vm.brand) === -1) {
+        return next(new errors.BrandNotSupportedError(
+            'snapshots are not supported for VMs of brand "' + vm.brand + '"'));
+    }
+    if (vm.datasets && vm.datasets.length && vm.datasets.length > 0) {
         return next(new errors.BrandNotSupportedError(
             'snapshots are not supported for VMs with delegated datasets'));
+    }
+    /*
+     * Until we properly handle docker filesystems being snapshotted,
+     * the only safe thing to do is reject all docker zones
+     */
+    if (vm.docker) {
+        return next(new errors.BrandNotSupportedError(
+            'snapshots are not supported for docker VMs'));
     }
 
     req.app.wfapi.createSnapshotJob(req, function (err, juuid) {
@@ -941,10 +952,17 @@ function rollbackSnapshot(req, res, next) {
     req.log.trace({ vm_uuid: req.params.uuid }, 'RollbackSnapshot start');
     var vm = req.vm;
 
-    if ((vm.brand !== 'joyent' && vm.brand !== 'joyent-minimal') ||
-        (vm.datasets && vm.datasets.length && vm.datasets.length > 0)) {
+    if (['joyent', 'joyent-minimal', 'sngl', 'lx'].indexOf(vm.brand) === -1) {
         return next(new errors.BrandNotSupportedError(
-            'VM \'brand\' does not support snapshots'));
+            'snapshots are not supported for VMs of brand "' + vm.brand + '"'));
+    }
+    if (vm.datasets && vm.datasets.length && vm.datasets.length > 0) {
+        return next(new errors.BrandNotSupportedError(
+            'snapshots are not supported for VMs with delegated datasets'));
+    }
+    if (vm.docker) {
+        return next(new errors.BrandNotSupportedError(
+            'snapshots are not supported for docker VMs'));
     }
 
     if (!req.params.snapshot_name) {
@@ -971,10 +989,17 @@ function deleteSnapshot(req, res, next) {
     req.log.trace({ vm_uuid: req.params.uuid }, 'DeleteSnapshot start');
     var vm = req.vm;
 
-    if ((vm.brand !== 'joyent' && vm.brand !== 'joyent-minimal') ||
-        (vm.datasets && vm.datasets.length && vm.datasets.length > 0)) {
+    if (['joyent', 'joyent-minimal', 'sngl', 'lx'].indexOf(vm.brand) === -1) {
         return next(new errors.BrandNotSupportedError(
-            'VM \'brand\' does not support snapshots'));
+            'snapshots are not supported for VMs of brand "' + vm.brand + '"'));
+    }
+    if (vm.datasets && vm.datasets.length && vm.datasets.length > 0) {
+        return next(new errors.BrandNotSupportedError(
+            'snapshots are not supported for VMs with delegated datasets'));
+    }
+    if (vm.docker) {
+        return next(new errors.BrandNotSupportedError(
+            'snapshots are not supported for docker VMs'));
     }
 
     if (!req.params.snapshot_name) {


### PR DESCRIPTION
Snapshots and rollbacks appear to be working fine for LX branded zones, so this patch enables the use of these operations on them in VMAPI.

It also cleans up the inconsistent/misleading error messages for any other brands in future (eg, before this patch, trying to take a snapshot of an LX branded zone returns an error talking about delegated datasets, when the LX zone does not have one)

@mscook found this one