### PR TITLE
DOCKER-557: fast `docker rm` without adding a transitive_state property on VM objects

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -259,7 +259,24 @@ endpoint:
 | provisioning | VM is currently being provisioned in the system |
 | incomplete   | |
 | failed       | VM provisioning has failed |
-| active       | When used in ListVms, denotes machines that are not 'destroyed' or 'failed' |
+| active       | When used in ListVms, denotes machines that are not in state 'destroyed', 'failed' or 'manual_override' |
+| destroying   | When used in ListVms, denotes machines that have a 'destroyed' state but a zone_state that is not 'destroyed' |
+| manual_override | Used as an intermediary state to make a VM transition from 'destroyed' to another state that is not 'destroyed'. The direct transition from a non destroyed state to a destroyed state is otherwise not allowed. |
+
+## State `'manual_override'`
+
+The state `'manual_override'` is a special state that is used to transition a
+VM from the state `'destroyed'` to any other state that is not `'destroyed'`.
+Without going through this `'manual_override'` state, a transition from state
+`'destroyed'` to any other state that is not `'manual_override'` is not
+allowed and generates an error.
+
+Transitioning a VM to the `'manual_override'` state should be exceptional and
+not part of normal procedures and workflows. It should be used to fix
+exceptional issues such as bugs in SDC that would erroneously set VMs in a
+state `'destroyed'`.
+
+## `zone_state` property
 
 <!-- TODO: validate this is the complete set. What is the translation from
 zone_state? -->
@@ -275,6 +292,7 @@ In addition, there is a 'zone_state' property that represents the Solaris Zones 
 | ready         |
 | running       |
 | shutting down |
+| destroyed     |
 
 
 # VM Features
@@ -413,7 +431,7 @@ will result in a request error.
 | brand            | String                                           | Brand of the VM (joyent, joyent-minimal or kvm) |
 | docker           | Boolean                                          | true if the VM is a docker VM, false otherwise  |
 | alias            | String                                           | VM Alias                                        |
-| state            | String                                           | running, stopped, active or destroyed           |
+| state            | String                                           | running, stopped, active, destroying, destroyed or manual_override |
 | ram              | Number                                           | Amount of memory of the VM                      |
 | uuids            | String (comma-separated UUID values)             | List of VM UUIDs to match                       |
 | create_timestamp | Unix Time in milliseconds or UTC ISO Date String | VM creation timestamp                           |

--- a/lib/apis/moray.js
+++ b/lib/apis/moray.js
@@ -29,32 +29,14 @@ var moray = require('moray');
 
 var SELECT_ALL_FILTER = '(uuid=*)';
 var PARAM_FILTER = '(%s=%s)';
-var PARAM_FILTER_GE = '(%s>=%s)';
-var PARAM_FILTER_LE = '(%s<=%s)';
 var PARAM_FILTER_NE = '(!(%s=%s))';
 
-// Only indexed columns can be searched
-var SEARCHABLE_FIELDS = [
-    'uuid',
-    'owner_uuid',
-    'image_uuid',
-    'billing_id',
-    'server_uuid',
-    'package_name',
-    'package_version',
-    'brand',
-    'state',
-    'alias',
-    'max_physical_memory',
-    'ram',
-    'create_timestamp'
-];
 
 /*
  * Basically the VMs table
  */
 var VMS_BUCKET_NAME = 'vmapi_vms';
-var VMS_BUCKET = {
+var VMS_BUCKET_SCHEMA = {
     index: {
         uuid: { type: 'string', unique: true},
         owner_uuid: { type: 'string' },
@@ -69,7 +51,11 @@ var VMS_BUCKET = {
         alias: { type: 'string' },
         max_physical_memory: { type: 'number' },
         create_timestamp: { type: 'number' },
-        docker: { type: 'boolean' }
+        docker: { type: 'boolean' },
+        zone_state: { type: 'string' }
+    },
+    options: {
+        version: 1
     }
 };
 
@@ -79,16 +65,23 @@ var VMS_BUCKET = {
  * can detect if a VM has been destroyed
  */
 var SERVER_VMS_BUCKET_NAME = 'vmapi_server_vms';
-var SERVER_VMS_BUCKET = {};
+var SERVER_VMS_BUCKET_SCHEMA = {
+    options: {
+        version: 1
+    }
+};
 
 
 /*
  * This table allows us to store role_tags for VMs
  */
 var VM_ROLE_TAGS_BUCKET_NAME = 'vmapi_vm_role_tags';
-var VM_ROLE_TAGS_BUCKET = {
+var VM_ROLE_TAGS_BUCKET_SCHEMA = {
     index: {
         role_tags: { type: '[string]' }
+    },
+    options: {
+        version: 1
     }
 };
 
@@ -147,10 +140,11 @@ Moray.prototype.connect = function () {
 
         self._setupBuckets(function (err) {
             if (err) {
-                self.log.error({ err: err }, 'Buckets were not loaded');
+                self.log.error({ err: err },
+                    'Error when setting up buckets, buckets were not loaded');
             } else {
                 self.emit('moray-ready');
-                self.log.info('Buckets have been loaded');
+                self.log.info('Buckets have been loaded successfully');
             }
         });
     });
@@ -220,7 +214,11 @@ Moray.prototype.getVm = function (params, cb) {
 /*
  * Gets VMs from a list of UUIDs
  */
-Moray.prototype.getVms = function (uuids, cb) {
+Moray.prototype.getVms = function (uuids, options, cb) {
+    assert.arrayOfString(uuids, 'uuids must be an array of strings');
+    assert.object(options, 'options must be an object');
+    assert.func(cb, 'cb must be a function');
+
     var filter = '';
     var i;
 
@@ -229,15 +227,16 @@ Moray.prototype.getVms = function (uuids, cb) {
     }
 
     filter = '(|' + filter + ')';
-    var vms = [];
-    var req = this.connection.findObjects(VMS_BUCKET_NAME, filter);
+    var vms = {};
+    var req = this.connection.findObjects(VMS_BUCKET_NAME, filter, options);
 
     req.once('error', function (err) {
         return cb(err);
     });
 
     req.on('record', function (object) {
-        vms.push(common.translateVm(object.value, true));
+        var vm = common.translateVm(object.value, true);
+        vms[vm.uuid] = vm;
     });
 
     req.once('end', function () {
@@ -330,7 +329,10 @@ Moray.prototype._vmsListParams = function (params, cb) {
 
     if (params.state) {
         if (params.state === 'active') {
-            filter.push('(&(!(state=destroyed))(!(state=failed)))');
+            filter.push('(&(!(state=destroyed))(!(state=failed))' +
+                '(!(state=manual_override)))');
+        } else if (params.state === 'destroying') {
+            filter.push('(&(state=destroyed)(!(zone_state=destroyed)))');
         } else {
             filter.push(sprintf(PARAM_FILTER, 'state', params.state));
         }
@@ -623,7 +625,7 @@ Moray.prototype.markAsDestroyed = function (vm, callback) {
     var state = (vm.state === 'provisioning') ? 'failed' : 'destroyed';
 
     vm.state = state;
-    vm.zone_state = state;
+
     if (state === 'destroyed') {
         vm.destroyed = new Date();
     }
@@ -839,29 +841,50 @@ Moray.prototype._setupBuckets = function (cb) {
     var self = this;
     var buckets = [ {
         name: VMS_BUCKET_NAME,
-        indices: VMS_BUCKET
+        schema: VMS_BUCKET_SCHEMA
     }, {
         name: SERVER_VMS_BUCKET_NAME,
-        indices: SERVER_VMS_BUCKET
+        schema: SERVER_VMS_BUCKET_SCHEMA
     }, {
         name: VM_ROLE_TAGS_BUCKET_NAME,
-        indices: VM_ROLE_TAGS_BUCKET
+        schema: VM_ROLE_TAGS_BUCKET_SCHEMA
     } ];
 
     async.mapSeries(buckets, function (bucket, next) {
         self._getBucket(bucket.name, function (err, bck) {
             if (err) {
                 if (err.name === 'BucketNotFoundError') {
-                    self._createBucket(bucket.name, bucket.indices, next);
+                    self.log.info('Bucket ' + bucket.name +
+                        ' not found, creating it...');
+                    return self._createBucket(bucket.name, bucket.schema, next);
                 } else {
-                    next(err);
+                    return next(err);
                 }
+            } else if (bck.options.version >= bucket.schema.options.version) {
+                self.log.info('Bucket ' + bucket.name +
+                    ' already exists at version ' + bck.options.version +
+                    ' and does not need to be updated to version ' +
+                    bucket.schema.options.version + ', nothing to do');
+
+                return next(null);
             } else {
-                next(null);
+                self.log.info('Bucket ' + bucket.name +
+                    ' needs to be updated from version ' +
+                    bck.options.version + ' to version ' +
+                    bucket.schema.options.version + '. Updating...');
+
+                return self._updateBucket(bucket.name, bucket.schema,
+                    function (updateErr) {
+                        if (updateErr) {
+                            return next(updateErr);
+                        }
+
+                        return self._reindexBucket(bucket.name, next);
+                    });
             }
         });
     }, function (err) {
-        cb(err);
+        return cb(err);
     });
 };
 
@@ -892,7 +915,9 @@ Moray.prototype._deleteBucket = function (name, cb) {
     this.connection.delBucket(name, cb);
 };
 
-
+Moray.prototype._updateBucket = function (name, schema, cb) {
+    this.connection.updateBucket(name, schema, cb);
+};
 
 /*
  * Converts to a valid moray VM object
@@ -1019,6 +1044,38 @@ Moray.prototype.delVmRoleTags = function (uuid, cb) {
             cb(err);
         }
     });
+};
+
+/**
+ * Reindexes all objects in the bucket if it has been updated.
+ *
+ * @param moray {MorayClient}
+ * @param bucketName {Name of the bucket to reindex}
+ * @param callback {Function} `function (err)`
+ */
+Moray.prototype._reindexBucket = function reindexBucket(bucketName, callback) {
+    assert.string(bucketName, 'bucketName must be a string');
+    assert.func(callback, 'callback must be a function');
+
+    var self = this;
+
+    var rowsPerCall = 100;
+    var processed = rowsPerCall;
+
+    async.whilst(
+        function () { return processed > 0; },
+        function (cb) {
+            self.connection.reindexObjects(bucketName, rowsPerCall,
+                { noCache: true },
+            function (err, res) {
+                if (err) {
+                    return cb(err);
+                }
+
+                processed = res.processed;
+                cb();
+            });
+        }, callback);
 };
 
 module.exports = Moray;

--- a/lib/common/util.js
+++ b/lib/common/util.js
@@ -138,13 +138,25 @@ exports.publishChange = publishChange;
 
 
 /*
- * Poll a job until it reaches either the succeeded or failed state.
+ * Poll a job until it:
+ * - reaches either the succeeded or failed state
+ * - completes a given task
+ *
+ * 'opts' is an options object whose properties can be:
+ * - 'taskName': a string that identifies the nane of the task to wait for
+ * before calling the callback 'cb'. If 'opts.taskName' is set, then pollJob
+ * will not wait for the whole job to succeed or fail, but instead will just
+ * wait for that specific task to complete.
  *
  * Note: if a job fails, it's the caller's responsibility to check for a failed
  * job.  The error object will be null even if the job fails.
  */
 
 function pollJob(opts, cb) {
+    assert.object(opts, 'opts must be an object');
+    assert.optionalString(opts.taskName,
+        'opts.taskName must be undefined or a string');
+
     var wfapi = opts.wfapi;
     var log = opts.log;
     var job_uuid = opts.job_uuid;
@@ -181,24 +193,31 @@ function pollJob(opts, cb) {
             log.debug({ job: job }, 'polling job %s (attempt %d)',
                       job_uuid, attempts);
 
-                      if (job && job.execution === 'succeeded') {
-                          return (cb(null, job));
-                      } else if (job && job.execution === 'failed') {
-                          log.warn('job %s failed', job_uuid);
-                          return (cb(null, job));
-                      } else if (job && job.execution === 'canceled') {
-                          log.warn('job %s was canceled', job_uuid);
-                          return (cb(null, job));
-                      } else if (attempts > limit) {
-                          log.warn('polling for job %s completion ' +
-                                   'timed out after %d seconds',
-                          job_uuid, limit * (timeout / 1000));
-                          return (cb(new Error(
-                              'polling for job timed out'), job));
-                      }
+            if (opts.taskName &&
+                job.execution === 'running' &&
+                job.chain_results &&
+                job.chain_results.some(function findTaskResultByName(result) {
+                    return result && result.name === opts.taskName;
+                })) {
+                return cb(null, job);
+            } else if (job && job.execution === 'succeeded') {
+              return (cb(null, job));
+            } else if (job && job.execution === 'failed') {
+              log.warn('job %s failed', job_uuid);
+              return (cb(null, job));
+            } else if (job && job.execution === 'canceled') {
+              log.warn('job %s was canceled', job_uuid);
+              return (cb(null, job));
+            } else if (attempts > limit) {
+              log.warn('polling for job %s completion ' +
+                       'timed out after %d seconds',
+              job_uuid, limit * (timeout / 1000));
+              return (cb(new Error(
+                  'polling for job timed out'), job));
+            }
 
-                      setTimeout(poll, timeout);
-                      return (null);
+            setTimeout(poll, timeout);
+            return (null);
         });
     };
 

--- a/lib/common/validation.js
+++ b/lib/common/validation.js
@@ -61,9 +61,28 @@ var VALID_VM_BRANDS = [
 var VALID_VM_STATES = [
     'running',
     'stopped',
+    'destroyed',
+    'failed',
+    'manual_override'
+];
+exports.VALID_VM_STATES = VALID_VM_STATES;
+
+var VALID_VM_STATES_ALIASES = [
     'active',
+    'destroying'
+];
+exports.VALID_VM_STATES_ALIASES = VALID_VM_STATES_ALIASES;
+
+var VALID_VM_ZONE_STATES = [
+    'configured',
+    'incomplete',
+    'installed',
+    'ready',
+    'running',
+    'shutting_down',
     'destroyed'
 ];
+exports.VALID_VM_ZONE_STATES = VALID_VM_ZONE_STATES;
 
 var DEFAULT_QUOTA = 10; // GiB
 var MIN_SWAP = 256;     // MiB
@@ -490,6 +509,7 @@ function createValidateArrayFn(field) {
  */
 function createValidateStringFn(field, options) {
     var regexp;
+    var expectedString;
 
     assert.string(field, 'field');
 
@@ -512,6 +532,13 @@ function createValidateStringFn(field, options) {
             if (regexp && !regexp.test(params[field]))
                 errs.push(errors.invalidParamErr(field,
                     'String does not match regexp: ' + regexp));
+
+            expectedString = options.expectedString;
+            if (expectedString && params[field] !== expectedString) {
+                errs.push(errors.invalidParamErr(field,
+                    'String does not match expected string: ' +
+                    expectedString));
+            }
         }
 
         return errs;
@@ -1379,7 +1406,8 @@ function validateListVmsParams(params, callback) {
                 uuids: createValidateCSVFn('uuids', validUUID),
                 brand: createValidateStringsListFn('brand', VALID_VM_BRANDS),
                 alias: createValidateStringFn('alias', {re: ALIAS_RE}),
-                state: createValidateStringsListFn('state', VALID_VM_STATES),
+                state: createValidateStringsListFn('state',
+                    VALID_VM_STATES.concat(VALID_VM_STATES_ALIASES)),
                 ram: createValidateStringFn('ram', {re: RAM_RE}),
                 predicate: createValidateJSONPredicateFn('predicate'),
                 query: createValidateStringFn('query'),

--- a/lib/common/vm-common.js
+++ b/lib/common/vm-common.js
@@ -491,10 +491,8 @@ exports.deleteAllMetadata = function (vm, mdataKey) {
 exports.getStatuses = function (vms) {
     var status = {};
 
-    for (var i = 0; i < vms.length; i++) {
-        if (vms[i]) {
-            status[vms[i].uuid] = vms[i].state;
-        }
+    for (var uuid in vms) {
+        status[uuid] = vms[uuid].state;
     }
 
     return status;

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -1,0 +1,69 @@
+var path = require('path');
+var fs = require('fs');
+
+/**
+ * boolFromString() "borrowed" from imgapi.git:lib/imgmanifest.js
+ *
+ * Convert a boolean or string representation (as in redis or UFDS or a
+ * query param) into a boolean, or raise TypeError trying.
+ *
+ * @param value {Boolean|String} The input value to convert.
+ * @param default_ {Boolean} The default value is `value` is undefined.
+ * @param errName {String} The variable name to quote in the possibly
+ *      raised TypeError.
+ */
+function boolFromString(value, default_, errName) {
+    if (value === undefined || value === '') {
+        return default_;
+    } else if (value === 'false') {
+        return false;
+    } else if (value === 'true') {
+        return true;
+    } else if (typeof (value) === 'boolean') {
+        return value;
+    } else {
+        throw new TypeError('invalid value for ' + errName + ': '
+            + JSON.stringify(value));
+    }
+}
+
+/*
+ * Loads and parse the configuration file config.json at the root
+ * of the project.
+ */
+function loadConfig() {
+    var configPath = path.join(__dirname, '..', 'config.json');
+
+    if (!fs.existsSync(configPath)) {
+        console.error('Config file not found: ' + configPath +
+          ' does not exist. Aborting.');
+        process.exit(1);
+    }
+
+    var theConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+    /*
+     * Fix Boolean value that should be default-true. hogan templates do not
+     * allow us to differentiate between unset and 'false', so we have 3
+     * possible string values for a "boolean" here:
+     *
+     *  ""       - unset, which we should treat as true
+     *  "true"
+     *  "false"
+     *
+     * This returns either true or false.
+     */
+    if (theConfig.hasOwnProperty('reserveKvmStorage')) {
+        theConfig.reserveKvmStorage = boolFromString(
+            theConfig.reserveKvmStorage, true, 'config.reserveKvmStorage');
+    } else {
+        // default to true
+        theConfig.reserveKvmStorage = true;
+    }
+
+    return theConfig;
+}
+
+module.exports = {
+    loadConfig: loadConfig
+};

--- a/lib/endpoints/statuses.js
+++ b/lib/endpoints/statuses.js
@@ -30,7 +30,7 @@ function listStatuses(req, res, next) {
         return next(new restify.MissingParameterError('uuids is required'));
     }
 
-    return req.app.moray.getVms(uuids.split(','), function (err, vms) {
+    return req.app.moray.getVms(uuids.split(','), {}, function (err, vms) {
         if (err) {
             return next(err);
         }

--- a/lib/endpoints/vms.js
+++ b/lib/endpoints/vms.js
@@ -332,6 +332,19 @@ function getVm(req, res, next) {
 
         if (vm) {
             var newVm = common.translateVm(vm, true);
+
+            // If a VM was marked as 'destroyed' by setting its "state"
+            // property to 'destroyed, it's possible that the destroy workflow
+            // failed and that the actual state of the VM is different than
+            // 'destroyed'. In this case, we prevent a sync GET to change
+            // the state of this VM to something else than 'destroyed' because
+            // This would 'unmark' this VM as 'in the process of being
+            // destroyed'. More generally, once a VM has been marked as
+            // destroyed, it cannot change its state to another state.
+            if (m.state === 'destroyed') {
+                newVm.state = m.state;
+            }
+
             req.app.moray.putVm(newVm.uuid, newVm, function (putErr) {
                 if (putErr) {
                     req.log.error({ err: putErr, uuid: newVm.uuid },
@@ -344,6 +357,7 @@ function getVm(req, res, next) {
             });
 
         } else {
+            req.vm.zone_state = 'destroyed';
             req.app.moray.markAsDestroyed(req.vm, function (markErr, modVm) {
                 if (markErr) {
                     return next(markErr);
@@ -361,7 +375,7 @@ function getVm(req, res, next) {
  * whether the sync parameter is specified.
  */
 
-function handleUpdateVMResponse(req, res, next, juuid) {
+function handleUpdateVMResponse(req, res, next, juuid, taskName) {
     // Allow clients to know the location of WFAPI
     res.header('workflow-api', req.app.config.wfapi.url);
 
@@ -377,7 +391,8 @@ function handleUpdateVMResponse(req, res, next, juuid) {
         var opts = {
             log: req.log,
             job_uuid: juuid,
-            wfapi: req.app.wfapi
+            wfapi: req.app.wfapi,
+            taskName: taskName
         };
         common.waitForJob(opts, function (error) {
             if (error) {
@@ -393,6 +408,56 @@ function handleUpdateVMResponse(req, res, next, juuid) {
 }
 
 
+/*
+ * Returns true if the action 'action' with parameters params is valid
+ * on a VM that is being destroyed, false otherwise.
+ */
+function destroyingVmUpdateValid(params, action) {
+    assert.object(params, 'params must be an object');
+    assert.string(action, 'action must be a string');
+
+    var paramNames, allowedParamNames, disallowedParamNames;
+    // When a VM has state === 'destroyed' and zone_state !==
+    // 'destroyed', it means that it's being destroyed, or that a
+    // previous destroy workflow failed. Any other action than setting
+    // its state to 'destroyed' is forbidden, except for:
+    //
+    // * Setting its 'indestructible_zoneroot' property in case it was
+    // set to true, and it needs to be set to false before deleting
+    // the VM.
+    //
+    // * Setting its zone_state to 'destroyed' once the VM is actually
+    // destroyed.
+    if (action !== 'update') {
+        return false;
+    } else {
+        allowedParamNames = [
+            'sync',
+            'uuid',
+            'indestructible_zoneroot',
+            'indestructible_delegated',
+            'action',
+            'zone_state',
+            'state'
+        ];
+
+        paramNames = Object.keys(params);
+        disallowedParamNames = paramNames.filter(function (paramName) {
+            return allowedParamNames.indexOf(paramName) === -1;
+         });
+
+        if (disallowedParamNames.length > 0) {
+            return false;
+        }
+
+        if (params.indestructible_zoneroot &&
+            params.indestructible_zoneroot !== false) {
+            return false;
+        }
+    }
+
+    return true;
+}
 
 /*
  * POST /vms/:uuid
@@ -403,6 +468,11 @@ function updateVm(req, res, next) {
     var action = req.params.action;
     var sync = req.params.sync;
     var error;
+    var vmBeingDestroyed = req.vm.state === 'destroyed' &&
+        req.vm.zone_state !== 'destroyed';
+    var vmAlreadyDestroyed = req.vm.state === 'destroyed' &&
+        req.vm.zone_state === 'destroyed';
+    var zoneStateChangeError, stateChangeError;
 
     if (!action) {
         error = [ errors.missingParamErr('action') ];
@@ -422,6 +492,29 @@ function updateVm(req, res, next) {
             error));
     } else {
         req.params.sync = (sync === 'true' ? true : false);
+    }
+
+    zoneStateChangeError = validZoneStateChange(req.vm, req.params);
+    if (zoneStateChangeError) {
+        return next(zoneStateChangeError);
+    }
+
+    stateChangeError = validStateChange(req.vm, req.params);
+    if (stateChangeError) {
+        // Silently override the params' state to be the current VM's state
+        // so that updates of other properties than state can happen from
+        // clients who have a different view of the VM's state than VMAPI
+        // (e.g vm-agent).
+        req.params.state = req.vm.state;
+    }
+
+    if (vmBeingDestroyed && !destroyingVmUpdateValid(req.params, action)) {
+        return next(new errors.VMBeingDestroyedError());
+    }
+
+    if (vmAlreadyDestroyed) {
+        // This VM has been destroyed, any update action is invalid
+        return next(new errors.ChangingDestroyedVMError());
     }
 
     switch (action) {
@@ -835,8 +928,13 @@ function deleteVm(req, res, next) {
                                 return next(jobErr);
                             }
 
+                            // If sync===true, do not wait until the VM has
+                            // actually been destroyed and the whole workflow
+                            // has completed. Only wait until the VM is marked
+                            // as destroyed (the 'vmapi.mark_vm_as_destroyed'
+                            // task is finished).
                             return handleUpdateVMResponse(req, res, next,
-                                juuid);
+                                juuid, 'vmapi.mark_vm_as_destroyed');
                         });
                 }
             });
@@ -1136,14 +1234,50 @@ function putVms(req, res, next) {
     }
 
     // TODO: It is broken that we don't check for deleted VMs when this happens
-    async.eachSeries(Object.keys(req.params.vms), function (uuid, cb) {
+    async.each(Object.keys(req.params.vms), function (uuid, cb) {
         var vm = common.translateVm(req.params.vms[uuid], false);
-        var oldVm = req.vms[uuid] || {};
+        var oldVm;
+
         async.waterfall([
-            function _morayPut(cb2) {
-                req.app.moray.putVm(uuid, vm, cb2);
+            function loadExistingVm(done) {
+                req.app.moray.getVm({uuid: uuid},
+                    function onGetVm(err, existingVm) {
+                        oldVm = existingVm;
+                        return done(err);
+                    });
             },
-            function _diffVms(etag, cb2) {
+            function _checkStateChanges(done) {
+                var stateChangeError;
+                var zoneStateChangeError;
+                if (oldVm) {
+                    stateChangeError = validStateChange(oldVm, vm);
+                    if (stateChangeError) {
+                        // Silently override the params' state to be the
+                        // current VM's state so that updates of other
+                        // properties than state can happen from clients
+                        // who have a different view of the VM's state than
+                        // VMAPI (e.g vm-agent).
+                        vm.state = oldVm.state;
+                    }
+
+                    // Contrary to the way we deal with invalid state
+                    // transitions by silently overriding them, do not silently
+                    // override the zone_state property if the current PUT /vms
+                    // request would trigger an invalid zone_state transition,
+                    // as this would be the sign of a problem in the system.
+                    zoneStateChangeError = validZoneStateChange(oldVm,
+                        vm);
+                    if (zoneStateChangeError) {
+                        return done(zoneStateChangeError);
+                    }
+                }
+
+                return done();
+            },
+            function _morayPut(done) {
+                req.app.moray.putVm(uuid, vm, done);
+            },
+            function _diffVms(etag, done) {
                 var diffs = [];
                 var diffResults = deepDiff.diff(oldVm, vm);
                 if (diffResults && diffResults.length) {
@@ -1157,14 +1291,14 @@ function putVms(req, res, next) {
                         }
                     }
                 }
-                cb2(null, diffs);
+                done(null, diffs);
             },
-            function _pub(diffs, cb2) {
+            function _pub(diffs, done) {
                 if (diffs && diffs.length != 0) {
                     var publisher = req.app.publisher;
-                    common.publishChange(publisher, VM, diffs, uuid, cb2);
+                    common.publishChange(publisher, VM, diffs, uuid, done);
                 } else {
-                    cb2(null);
+                    done(null);
                 }
             }
         ], function _waterfallEnd(err) {
@@ -1181,7 +1315,52 @@ function putVms(req, res, next) {
     });
 }
 
+/*
+ * Returns true if the transition from existingVm to newVm represents a
+ * valid state transition, false otherwise.
+ */
+function validStateChange(existingVm, newVm) {
+    assert.object(existingVm, 'existingVm must be an object');
+    assert.object(newVm, 'newVm must be an object');
 
+    var changingVmState = newVm.state !== undefined &&
+        newVm.state !== existingVm.state;
+    var existingVmBeingDestroyed = existingVm.state === 'destroyed' &&
+        existingVm.zone_state !== 'destroyed';
+
+    if (existingVm.state === 'destroyed' &&
+        changingVmState &&
+        newVm.state !== 'destroyed' &&
+        newVm.state !== 'manual_override') {
+        // Once a VM is in the 'destroyed' state, it cannot change
+        // its state
+        if (existingVmBeingDestroyed) {
+            return new errors.VMBeingDestroyedError();
+        } else {
+            return new errors.ChangingDestroyedVMError();
+        }
+    }
+}
+
+/*
+ * Returns true if the transition from existingVm to newVm represents a
+ * valid zone_state transition, false otherwise.
+ */
+function validZoneStateChange(existingVm, newVm) {
+    assert.object(existingVm, 'existingVm must be an object');
+    assert.object(newVm, 'newVm must be an object');
+
+    var changingVmZoneState = newVm.zone_state != null &&
+        newVm.zone_state !== existingVm.zone_state;
+
+    if (changingVmZoneState &&
+        existingVm.zone_state === 'destroyed' &&
+        newVm.zone_state !== 'destroyed') {
+        // Changing the zone_state of a VM that destroyed to another zone_state
+        // that is *not* destroyed is invalid and results in an error.
+        return new errors.ChangingDestroyedVMError();
+    }
+}
 
 /*
  * Replaces a VM
@@ -1189,6 +1368,9 @@ function putVms(req, res, next) {
 function putVm(req, res, next) {
     var log = req.log;
     log.trace('PutVm start');
+
+    var existingVm = req.vm;
+    var stateChangeError, zoneStateChangeError;
 
     if (!common.validUUID(req.params.uuid)) {
         var error = [ errors.invalidUuidErr('uuid') ];
@@ -1199,6 +1381,28 @@ function putVm(req, res, next) {
     // Parse whatever is needed before putting a raw object from vm-agent
     var vm = common.translateVm(req.params, false);
     var publisher = req.app.publisher;
+
+    if (existingVm) {
+        stateChangeError = validStateChange(existingVm, vm);
+        if (stateChangeError) {
+            // Silently override the params' state to be the current VM's state
+            // so that updates of other properties than state can happen from
+            // clients who have a different view of the VM's state than VMAPI
+            // (e.g vm-agent).
+            vm.state = existingVm.state;
+        }
+
+        zoneStateChangeError = validZoneStateChange(existingVm, vm);
+        if (zoneStateChangeError) {
+            // Trying to change zone_state in a way that is not valid is an
+            // error, and should not result in a slient override. For instance,
+            // having vm-agent set zone_state !== 'destroyed' for a VM that had
+            // previously been set to zone_state === 'destroyed' should never
+            // happen, because that means the VM should have been gone from the
+            // CN at that point.
+            return next(zoneStateChangeError);
+        }
+    }
 
     if (vm.state === 'destroyed') {
         _destroyVm(vm, {
@@ -1283,26 +1487,6 @@ function _loadVm(req, res, next) {
     }
 }
 
-function _loadVms(req, res, next) {
-    if (!req.query.server_uuid || !req.params.vms) {
-        next();
-        return;
-    }
-
-    req.app.moray.listVmsForServer(req.query.server_uuid, _serverVms);
-    function _serverVms(err, vms) {
-        if (err) {
-            next(err);
-            return;
-        }
-
-        if (vms) {
-            req.vms = vms;
-        }
-
-        next();
-    }
-}
 
 /*
  * Mounts vm actions as server routes
@@ -1352,7 +1536,6 @@ function mount(server) {
 
     server.put({ path: '/vms', name: 'PutVms' },
         interceptors.checkWfapi,
-        _loadVms,
         putVms);
 }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -223,8 +223,58 @@ exports.wfapiWrap = function (opts) {
     return new _WorkflowError();
 };
 
+/*
+ * This error is produced when trying to call an action on a VM that is beying
+ * destroyed (state === 'destroyed' && zone_state !== 'destroyed').
+ * The only action allowed on such VMs is a POST with action=update and a
+ * payload that only contains a value for the indestructible_zoneroot property
+ * so that indestructible VMs can have this property disabled and be deleted.
+ */
+function VMBeingDestroyedError() {
+    var message = 'Invalid operation while this VM is being destroyed';
+
+    restify.RestError.call(this, {
+        restCode: this.constructor.restCode,
+        statusCode: this.constructor.statusCode,
+        message: message,
+        body: {
+            code: this.constructor.restCode,
+            message: message
+        }
+    });
+}
+
+util.inherits(VMBeingDestroyedError, restify.RestError);
+VMBeingDestroyedError.prototype.name = 'VMBeingDestroyedError';
+VMBeingDestroyedError.restCode = 'VMBeingDestroyed';
+VMBeingDestroyedError.statusCode = 409;
+
+/*
+ * This error is produced when trying to call an action on a VM that is
+ * already destroyed (state === 'destroyed').
+ */
+function ChangingDestroyedVMError() {
+    var message = 'Invalid operation on a destroyed VM';
+
+    restify.RestError.call(this, {
+        restCode: this.constructor.restCode,
+        statusCode: this.constructor.statusCode,
+        message: message,
+        body: {
+            code: this.constructor.restCode,
+            message: message
+        }
+    });
+}
+
+util.inherits(ChangingDestroyedVMError, restify.RestError);
+ChangingDestroyedVMError.prototype.name = 'ChangingDestroyedVMError';
+ChangingDestroyedVMError.restCode = 'ChangingDestroyedVM';
+ChangingDestroyedVMError.statusCode = 409;
 
 exports.UnallocatedVMError = UnallocatedVMError;
 exports.ValidationFailedError = ValidationFailedError;
 exports.BrandNotSupportedError = BrandNotSupportedError;
 exports.VmNotRunningError = VmNotRunningError;
+exports.VMBeingDestroyedError = VMBeingDestroyedError;
+exports.ChangingDestroyedVMError = ChangingDestroyedVMError;

--- a/lib/interceptors.js
+++ b/lib/interceptors.js
@@ -13,8 +13,9 @@
  */
 
 var restify = require('restify');
+var assert = require('assert-plus');
 var common = require('./common');
-
+var errors = require('./errors');
 
 
 /*

--- a/lib/workflows/destroy.js
+++ b/lib/workflows/destroy.js
@@ -19,14 +19,14 @@ var VERSION = '7.1.0';
 
 
 /*
- * Sets up a CNAPI VM action request. Take a look at common.zoneAction. Here you
- * can set parameters such as:
+ * Sets up a CNAPI VM destroy action request. Take a look at common.zoneAction.
+ * Here you can set parameters such as:
  * - request endpoint (usually the VM endpoint)
  * - jobid (so CNAPI can post status updates back to the job info object)
  * - requestMethod
  * - expects (if you want to check a specific running status of the machine)
  */
-function setupRequest(job, cb) {
+function setupDestroyRequest(job, cb) {
     job.endpoint = '/servers/' +
                    job.params['server_uuid'] + '/vms/' +
                    job.params['vm_uuid'] + '?jobid=' + job.uuid;
@@ -38,9 +38,32 @@ function setupRequest(job, cb) {
     job.action = 'destroy';
     job.server_uuid = job.params['server_uuid'];
 
-    return cb(null, 'Request has been setup!');
+    return cb(null, 'Destroy request has been setup!');
 }
 
+/*
+ * Sets up a CNAPI VM stop action request. Take a look at common.zoneAction.
+ * Here you can set parameters such as:
+ * - request endpoint (usually the VM endpoint)
+ * - jobid (so CNAPI can post status updates back to the job info object)
+ * - requestMethod
+ * - expects (if you want to check a specific running status of the machine)
+ */
+function setupStopRequest(job, cb) {
+    job.endpoint = '/servers/' +
+                   job.params['server_uuid'] + '/vms/' +
+                   job.params['vm_uuid'] + '/stop' +
+                   '?force=true&jobid=' + job.uuid;
+    job.currentVm = job.params.currentVm;
+    job.params.jobid = job.uuid;
+    job.requestMethod = 'post';
+    job.expects = 'stopped';
+    job.addedToUfds = true;
+    job.action = 'stop';
+    job.server_uuid = job.params['server_uuid'];
+
+    return cb(null, 'Stop request has been setup!');
+}
 
 /*
  * Allow the VM to be marked as destroyed preemptively on VMAPI as soon as
@@ -49,10 +72,6 @@ function setupRequest(job, cb) {
 function markVmAsDestroyed(job, cb) {
     if (!job.currentVm) {
         cb(null, 'Skipping task -- VM missing from job');
-        return;
-    }
-    if (!job.currentVm.docker) {
-        cb(null, 'Skipping task for non-Docker VMs');
         return;
     }
 
@@ -167,10 +186,10 @@ var workflow = module.exports = {
         body: common.validateForZoneAction,
         modules: {}
     }, {
-        name: 'common.setup_request',
+        name: 'common.setup_stop_request',
         timeout: 10,
         retry: 1,
-        body: setupRequest,
+        body: setupStopRequest,
         modules: {}
     }, {
         name: 'cnapi.acquire_vm_ticket',
@@ -185,7 +204,7 @@ var workflow = module.exports = {
         body: common.waitOnVMTicket,
         modules: { sdcClients: 'sdc-clients' }
     }, {
-        name: 'cnapi.destroy_vm',
+        name: 'cnapi.stop_vm',
         timeout: 10,
         retry: 1,
         body: common.zoneAction,
@@ -197,7 +216,25 @@ var workflow = module.exports = {
         body: markVmAsDestroyed,
         modules: { restify: 'restify' }
     }, {
-        name: 'cnapi.wait_task',
+        name: 'cnapi.wait_stop_vm_task',
+        timeout: 120,
+        retry: 1,
+        body: common.waitTask,
+        modules: { sdcClients: 'sdc-clients' }
+    }, {
+        name: 'common.setup_destroy_request',
+        timeout: 10,
+        retry: 1,
+        body: setupDestroyRequest,
+        modules: {}
+    }, {
+        name: 'cnapi.destroy_vm',
+        timeout: 10,
+        retry: 1,
+        body: common.zoneAction,
+        modules: { restify: 'restify' }
+    }, {
+        name: 'cnapi.wait_destroy_vm_task',
         timeout: 120,
         retry: 1,
         body: common.waitTask,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "async": "0.2.6",
     "bunyan": "1.3.4",
     "changefeed": "1.1.3",
+    "clone": "^1.0.2",
     "deep-diff": "0.3.3",
     "effluent-logger": "git+https://github.com/joshwilsdon/effluent-logger.git#d662f161a07f94045ad2afb45442931511c40e51",
     "filed": "0.0.5",
@@ -18,7 +19,7 @@
     "moray": "git+ssh://git@github.com:joyent/node-moray.git#b84ef0e",
     "nodeunit": "0.9.1",
     "restify": "2.7.0",
-    "sdc-clients": "git+ssh://git@github.com:joyent/node-sdc-clients.git#c962959",
+    "sdc-clients": "git+ssh://git@github.com:joyent/node-sdc-clients.git#ad24d7f",
     "sigyan": "0.2.0",
     "sprintf": "0.1.1",
     "trace-event": "1.3.0",
@@ -29,7 +30,11 @@
     "vm-agent": ">=1.5.0"
   },
   "devDependencies": {
+    "dashdash": "1.10.1",
     "tap": "*"
+  },
+  "optionalDependencies": {
+    "dtrace-provider": "0.2.8"
   },
   "scripts": {
     "start": "node ./server.js"

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ var path = require('path');
 var fs = require('fs');
 
 var VMAPI = require('./lib/vmapi');
+var configLoader = require('./lib/config-loader');
 
 var VERSION = false;
 
@@ -35,69 +36,7 @@ function version() {
     return VERSION;
 }
 
-/**
- * boolFromString() "borrowed" from imgapi.git:lib/imgmanifest.js
- *
- * Convert a boolean or string representation (as in redis or UFDS or a
- * query param) into a boolean, or raise TypeError trying.
- *
- * @param value {Boolean|String} The input value to convert.
- * @param default_ {Boolean} The default value is `value` is undefined.
- * @param errName {String} The variable name to quote in the possibly
- *      raised TypeError.
- */
-function boolFromString(value, default_, errName) {
-    if (value === undefined || value === '') {
-        return default_;
-    } else if (value === 'false') {
-        return false;
-    } else if (value === 'true') {
-        return true;
-    } else if (typeof (value) === 'boolean') {
-        return value;
-    } else {
-        throw new TypeError('invalid value for ' + errName + ': '
-            + JSON.stringify(value));
-    }
-}
-
-/*
- * Loads and parse the configuration file at config.json
- */
-function loadConfig() {
-    var configPath = path.join(__dirname, 'config.json');
-
-    if (!fs.existsSync(configPath)) {
-        console.error('Config file not found: ' + configPath +
-          ' does not exist. Aborting.');
-        process.exit(1);
-    }
-
-    var theConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-
-    /*
-     * Fix Boolean value that should be default-true. hogan templates do not
-     * allow us to differentiate between unset and 'false', so we have 3
-     * possible string values for a "boolean" here:
-     *
-     *  ""       - unset, which we should treat as true
-     *  "true"
-     *  "false"
-     *
-     * This returns either true or false.
-     */
-    if (theConfig.hasOwnProperty('reserveKvmStorage')) {
-        theConfig.reserveKvmStorage = boolFromString(
-            theConfig.reserveKvmStorage, true, 'config.reserveKvmStorage');
-    } else {
-        // default to true
-        theConfig.reserveKvmStorage = true;
-    }
-
-    return theConfig;
-}
-
-var config = loadConfig();
+var config = configLoader.loadConfig();
 config.version = version() || '7.0.0';
 
 

--- a/test/common.js
+++ b/test/common.js
@@ -17,7 +17,7 @@ var util = require('util');
 
 var Logger = require('bunyan');
 var restify = require('restify');
-
+var vmapiSdcClient = require('sdc-clients').VMAPI;
 
 // --- Globals
 
@@ -59,6 +59,16 @@ function setUp(callback) {
         agent: false
     });
 
+    var sdcClient = new vmapiSdcClient({
+        url: VMAPI_URL,
+        retry: {
+            retries: 1,
+            minTimeout: 1000
+        },
+        log: logger,
+        agent: false
+    });
+
     var napi = restify.createJsonClient({
         url: NAPI_URL,
         version: '*',
@@ -73,6 +83,7 @@ function setUp(callback) {
         agent: false
     });
 
+    client.sdcClient = sdcClient;
     client.napi = napi;
     client.cnapi = cnapi;
 

--- a/test/lib/vm.js
+++ b/test/lib/vm.js
@@ -1,10 +1,9 @@
 var assert = require('assert-plus');
-
 var libuuid = require('libuuid');
 
 var common = require('../../lib/common');
 
-var TEST_VMS_ALIAS = 'test--';
+var TEST_VMS_ALIAS = 'test-vmapi--';
 exports.TEST_VMS_ALIAS = TEST_VMS_ALIAS;
 
 function BunyanNoopLogger() {}

--- a/test/lib/workflow.js
+++ b/test/lib/workflow.js
@@ -1,0 +1,79 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2015, Joyent, Inc.
+ */
+
+// In seconds
+var TIMEOUT = 120;
+
+function checkJob(t, job) {
+    t.ok(job.uuid, 'uuid');
+    t.ok(job.name, 'name');
+    t.ok(job.execution, 'execution');
+    t.ok(job.params, 'params');
+}
+
+
+function checkEqual(value, expected) {
+    if ((typeof (value) === 'object') && (typeof (expected) === 'object')) {
+        var exkeys = Object.keys(expected);
+        for (var i = 0; i < exkeys.length; i++) {
+            var key = exkeys[i];
+            if (value[key] !== expected[key])
+                return false;
+        }
+
+        return true;
+    } else {
+        return (value === expected);
+    }
+}
+
+
+function checkValue(client, url, key, value, callback) {
+    return client.get(url, function (err, req, res, body) {
+        if (err) {
+            return callback(err);
+        }
+
+        return callback(null, checkEqual(body[key], value));
+    });
+}
+
+function waitForValue(client, url, key, value, callback) {
+    var times = 0;
+
+    function onReady(err, ready) {
+        if (err) {
+            callback(err);
+            return;
+        }
+
+        if (!ready) {
+            times++;
+
+            if (times == TIMEOUT) {
+                throw new Error('Timeout waiting on ' + url);
+            } else {
+                setTimeout(function () {
+                    waitForValue(client, url, key, value, callback);
+                }, 1000);
+            }
+        } else {
+            times = 0;
+            callback(null);
+        }
+    }
+
+    return checkValue(client, url, key, value, onReady);
+}
+
+module.exports = {
+    checkJob: checkJob,
+    waitForValue: waitForValue
+};

--- a/test/vms.changefeed.test.js
+++ b/test/vms.changefeed.test.js
@@ -17,6 +17,7 @@ var restify = require('restify');
 var uuid = require('libuuid');
 
 var common = require('./common');
+var vmTest = require('./lib/vm');
 
 var client;
 
@@ -231,7 +232,8 @@ exports.create_vm = function (t) {
         quota: 10,
         customer_metadata: md,
         creator_uuid: CUSTOMER,
-        role_tags: ['fd48177c-d7c3-11e3-9330-28cfe91a33c9']
+        role_tags: ['fd48177c-d7c3-11e3-9330-28cfe91a33c9'],
+        alias: vmTest.TEST_VMS_ALIAS
     };
 
     var opts = createOpts('/vms', vm);
@@ -603,7 +605,7 @@ exports.listen_for_destroy = function (t) {
 exports.put_new_vm = function (t) {
     t.expect(2);
     var vm = VM;
-    vm.alias = 'garbage' + uuid.create();
+    vm.alias = vmTest.TEST_VMS_ALIAS + uuid.create();
     vm.uuid = uuid.create();
     var opts = { path: '/vms/' + vm.uuid };
 
@@ -621,7 +623,7 @@ exports.put_new_vm = function (t) {
 exports.put_new_vms = function (t) {
     t.expect(2);
     var vm = VM;
-    vm.alias = 'garbage' + uuid.create();
+    vm.alias = vmTest.TEST_VMS_ALIAS + uuid.create();
     vm.uuid = uuid.create();
     var query = { server_uuid: SERVER.uuid };
     var opts = { path: '/vms', query: query };

--- a/test/vms.destroy.test.js
+++ b/test/vms.destroy.test.js
@@ -1,0 +1,528 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2015, Joyent, Inc.
+ */
+
+var assert = require('assert-plus');
+var vasync = require('vasync');
+var clone = require('clone');
+var ldapjs = require('ldapjs');
+
+var common = require('../lib/common');
+var testCommon = require('./common');
+var workflow = require('./lib/workflow');
+var vmTest = require('./lib/vm');
+
+var client;
+var MORAY = require('../lib/apis/moray');
+
+var IMAGE = 'fd2cc906-8938-11e3-beab-4359c665ac99';
+var CUSTOMER = testCommon.config.ufdsAdminUuid;
+var NETWORKS = null;
+var SERVER = null;
+
+var VMS_LIST_ENDPOINT = '/vms';
+
+var vmLocation;
+var jobLocation;
+var vmUuid;
+var vmObject;
+var leftoverTestVms = [];
+var leftoverTestVmsDestroyJobUuids = [];
+
+exports.setUp = function (callback) {
+    testCommon.setUp(function (err, _client) {
+        assert.ifError(err);
+        assert.ok(_client, 'restify client');
+        client = _client;
+        callback();
+    });
+};
+
+exports.find_headnode = function (t) {
+    client.cnapi.get('/servers?headnode=true',
+        function (err, req, res, servers) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.ok(servers);
+            t.ok(Array.isArray(servers));
+            for (var i = 0; i < servers.length; i++) {
+                if (servers[i].headnode === true) {
+                    SERVER = servers[i];
+                    break;
+                }
+            }
+            t.ok(SERVER);
+            t.done();
+        });
+};
+
+exports.napi_networks_ok = function (t) {
+    client.napi.get('/networks?provisionable_by=' + CUSTOMER,
+        function (err, req, res, networks) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.ok(networks);
+            t.ok(Array.isArray(networks));
+            t.ok(networks.length > 1);
+            NETWORKS = networks;
+            t.done();
+        });
+};
+
+/*
+ * Fist, delete any leftover VMs from a previous tests run that may not have
+ * been cleaned up properly.
+ */
+exports.get_leftover_test_vms = function (t) {
+    vasync.pipeline({
+        funcs: [
+            function getDestroyingLeftoverVms(args, callback) {
+                client.get(VMS_LIST_ENDPOINT + '?alias=' +
+                    vmTest.TEST_VMS_ALIAS + '&state=destroying',
+                    function (err, req, res, body) {
+                        t.equal(res.statusCode, 200);
+                        t.ok(Array.isArray(body));
+
+                        leftoverTestVms = leftoverTestVms.concat(body);
+                        return callback(err);
+                    });
+            },
+            function getActiveLeftoverVms(args, callback) {
+                client.get(VMS_LIST_ENDPOINT + '?alias=' +
+                    vmTest.TEST_VMS_ALIAS + '&state=active',
+                    function (err, req, res, body) {
+                        t.equal(res.statusCode, 200);
+                        t.ok(Array.isArray(body));
+
+                        leftoverTestVms = leftoverTestVms.concat(body);
+                        return callback(err);
+                    });
+            }
+        ]
+    }, function allDone(err) {
+        t.ifError(err);
+        t.done();
+    });
+};
+
+exports.remove_leftover_test_vms = function (t) {
+    function removeLeftoverVm(testVm, callback) {
+        var testVmLocation = '/vms/' + testVm.uuid;
+        vasync.pipeline({
+            funcs: [
+                function updateIndestructibleFlag(arg, next) {
+                    // First make sure that the indestructible_zoneroot
+                    // property is false so that we can actually destroy
+                    // this VM.
+                    client.post(testVmLocation + '?action=update&sync=true',
+                        {indestructible_zoneroot: false},
+                        function (err, req, res, body) {
+                            t.equal(res.statusCode, 202);
+                            return next(err);
+                        });
+                },
+                function removeVm(arg, next) {
+                    // Then actually delete it
+                    client.del(testVmLocation,
+                        function (err, req, res, body) {
+                            t.ifError(err);
+                            t.equal(res.statusCode, 202);
+                            testCommon.checkHeaders(t, res.headers);
+                            t.ok(body);
+                            leftoverTestVmsDestroyJobUuids.push(body.job_uuid);
+
+                            return next();
+                        });
+                }
+            ]
+        }, function done(err) {
+            return callback(err);
+        });
+    }
+
+    vasync.forEachPipeline({
+        inputs: leftoverTestVms,
+        func: removeLeftoverVm
+    }, function allVmsDestroyed(err) {
+        t.ifError(err);
+        t.done();
+    });
+};
+
+exports.wait_for_leftover_vms_to_actually_be_destroyed = function (t) {
+    vasync.forEachParallel({
+        inputs: leftoverTestVmsDestroyJobUuids,
+        func: function (jobUuid, next) {
+            var destroyJobLocation = '/jobs/' + jobUuid;
+            workflow.waitForValue(client, destroyJobLocation, 'execution',
+                'succeeded', next);
+        }
+    }, function allDestroyJobsDone(err) {
+        t.ifError(err);
+        t.done();
+    });
+};
+
+/*
+ * Now create a new "indestructible" VM that will be our guinea pig
+ * for the rest of this tests suite.
+ */
+
+exports.create_indestructible_vm = function (t) {
+    var md = {
+        foo: 'bar',
+        credentials: JSON.stringify({ 'user_pw': '12345678' })
+    };
+
+    var opts = {path: VMS_LIST_ENDPOINT};
+
+    var INDESTRUCTIBLE_VM_PAYLOAD = {
+        owner_uuid: CUSTOMER,
+        image_uuid: IMAGE,
+        server_uuid: SERVER.uuid,
+        networks: [ { uuid: NETWORKS[0].uuid } ],
+        brand: 'joyent-minimal',
+        billing_id: '00000000-0000-0000-0000-000000000000',
+        ram: 64,
+        quota: 10,
+        customer_metadata: md,
+        creator_uuid: CUSTOMER,
+        indestructible_zoneroot: true,
+        alias: vmTest.TEST_VMS_ALIAS
+    };
+
+    client.post(opts, INDESTRUCTIBLE_VM_PAYLOAD,
+        function (err, req, res, body) {
+            t.ifError(err);
+            t.equal(res.statusCode, 202);
+            testCommon.checkHeaders(t, res.headers);
+            t.ok(res.headers['workflow-api'], 'workflow-api header');
+            t.ok(body, 'vm ok');
+
+            jobLocation = '/jobs/' + body.job_uuid;
+            vmUuid = body.vm_uuid;
+            vmLocation = '/vms/' + vmUuid;
+            t.done();
+        });
+};
+
+exports.get_job = function (t) {
+    client.get(jobLocation, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200, 'GetJob 200 OK');
+        testCommon.checkHeaders(t, res.headers);
+        t.ok(body, 'job ok');
+        workflow.checkJob(t, body);
+        t.done();
+    });
+};
+
+exports.wait_provisioned_job = function (t) {
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
+};
+
+exports.try_destroy_indestructible_vm = function (t) {
+    client.del(vmLocation, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        testCommon.checkHeaders(t, res.headers);
+        t.ok(body);
+        jobLocation = '/jobs/' + body.job_uuid;
+        console.log('job location:', jobLocation);
+        t.done();
+    });
+};
+
+exports.wait_destroy_vm_failure = function (t) {
+    workflow.waitForValue(client, jobLocation, 'execution', 'failed',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
+};
+
+exports.update_vmapi_cache_and_check_installed_state = function (t) {
+    client.get(vmLocation + '?sync=true', function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        vmObject = body;
+
+        t.equal(vmObject.state, 'destroyed', 'state should be "destroyed"');
+        t.equal(vmObject.zone_state, 'installed',
+            'zone_state should be "installed"');
+        t.done();
+    });
+};
+
+exports.list_active_do_not_include_vms_being_destroyed = function (t) {
+    client.get(VMS_LIST_ENDPOINT + '?state=active',
+        function (err, req, res, body) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.ok(Array.isArray(body), 'response should be an array');
+            t.equal(false, body.some(function (vm) {
+                return vm.uuid === vmUuid;
+            }), 'The VM being destroyed should not be present in the list ' +
+                'of active VMs');
+            t.done();
+        });
+};
+
+exports.get_destroying_vms_lists_one_vm = function (t) {
+    client.get(VMS_LIST_ENDPOINT + '?state=destroying',
+        function (err, req, res, body) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.ok(Array.isArray(body), 'response should be an array');
+            t.equal(body.length, 1,
+                'Only one VM should be in state === \'destroying\'');
+            t.ok(body.length === 1 && body[0].uuid === vmUuid,
+                'The only VM being destroyed must have the same UUID as the ' +
+                'one we just tried to destroy');
+            t.done();
+        });
+};
+
+exports.put_on_destroying_vm_with_non_destroyed_state_must_fail = function (t) {
+    vasync.forEachParallel({
+        inputs: common.VALID_VM_STATES,
+        func: function (vmState, next) {
+            var vmInNewState = clone(vmObject);
+
+            // Do not set the state to 'manual_override', as it would change
+            // the VM state to 'manual_override' and we want the VM to be in
+            // state 'destoyed' for the duration of this test.
+            if (vmState === 'manual_override') {
+                return next();
+            }
+
+            vmInNewState.state = vmState;
+            client.put(vmLocation, vmInNewState,
+                function (err, req, res, body) {
+                    // Setting the state of a VM that is being destroyed
+                    // to any state, including to another state that is *not*
+                    // 'destroyed' is a valid operation, but the state of the
+                    // VM is actually _not_ changed.
+                    t.equal(res.statusCode, 200);
+                    t.equal(body.state, 'destroyed');
+
+                    return next();
+                });
+        }
+    }, function allDone(err) {
+        t.ifError(err);
+        t.done();
+    });
+};
+
+exports.post_on_destroying_vm_must_fail = function (t) {
+    var UPDATE_VM_ACTIONS = [
+        'start',
+        'stop',
+        'kill',
+        'reboot',
+        'update',
+        'reprovision',
+        'add_nics',
+        'update_nics',
+        'remove_nics',
+        'create_snapshot',
+        'rollback_snapshot',
+        'delete_snapshot'
+    ];
+
+    vasync.forEachParallel({
+        inputs: UPDATE_VM_ACTIONS,
+        func: function (updateVmAction, next) {
+            client.post(vmLocation + '?action=' + updateVmAction, {foo: 'bar'},
+                function (err, req, res, body) {
+                    t.equal(res.statusCode, 409);
+                    var expectedError = {
+                        code: 'VMBeingDestroyed',
+                        message:
+                            'Invalid operation while this VM is being destroyed'
+                    };
+                    t.deepEqual(body, expectedError);
+                    return next();
+                });
+        }
+    }, function allDone(err) {
+        t.ifError(err);
+        t.done();
+    });
+};
+
+exports.remove_indestructible_flag = function (t) {
+    client.post(vmLocation + '?action=update&sync=true',
+        {indestructible_zoneroot: false}, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        t.done();
+    });
+};
+
+exports.check_indestructible_flag_is_removed = function (t) {
+    // Use sync=true here to make sure that the VM's properties
+    // are updated before we test their values.
+    client.get(vmLocation + '?sync=true', function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        vmObject = body;
+
+        t.ok(vmObject.indestructible_zoneroot === false ||
+            vmObject.indestructible_zoneroot === undefined,
+            'indestructible_zoneroot flag should now be set to false');
+        t.done();
+    });
+};
+exports.destroy_destructible_vm = function (t) {
+    var opts = {path: vmLocation};
+
+    client.del(opts, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        testCommon.checkHeaders(t, res.headers);
+        t.ok(body);
+        jobLocation = '/jobs/' + body.job_uuid;
+        t.done();
+    });
+};
+
+exports.wait_destroy_vm_succeeded = function (t) {
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
+};
+
+exports.check_destroyed_vm_state = function (t) {
+    // Use sync=true here to make sure that the VM's properties
+    // are updated before we test their values.
+    client.get(vmLocation + '?sync=true', function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        vmObject = body;
+
+        t.equal(vmObject.state, 'destroyed', 'state should be "destroyed"');
+        t.equal(vmObject.zone_state, 'destroyed',
+            'zone_state should be "destroyed"');
+
+        t.done();
+    });
+};
+
+exports.get_destroying_vms_before_updating_cache_lists_no_vm = function (t) {
+    client.get(VMS_LIST_ENDPOINT + '?state=destroying',
+        function (err, req, res, body) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.ok(Array.isArray(body), 'response should be an array');
+            t.equal(body.length, 0,
+                'No VM should be in state === \'destroying\'');
+            t.done();
+        });
+};
+
+exports.get_destroying_vms_after_updating_cache_lists_no_vm = function (t) {
+    client.get(VMS_LIST_ENDPOINT + '?state=destroying',
+        function (err, req, res, body) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.ok(Array.isArray(body), 'response should be an array');
+            t.equal(body.length, 0,
+                'No VM should be in state === \'destroying\'');
+            t.done();
+        });
+};
+
+exports.put_on_destroyed_vm_with_non_destroyed_state_must_fail = function (t) {
+    vasync.forEachParallel({
+        inputs: common.VALID_VM_STATES,
+        func: function (vmState, next) {
+            // Do not set the state to 'manual_override', as it would change
+            // the VM state to 'manual_override' and we want the VM to be in
+            // state 'destoyed' for the duration of this test.
+            if (vmState === 'manual_override') {
+                return next();
+            }
+
+            var vmInNewState = clone(vmObject);
+            vmInNewState.state = vmState;
+            client.put(vmLocation, vmInNewState,
+                function (err, req, res, body) {
+                    // Setting the state of a VM that is being destroyed
+                    // to any state, including to another state that is *not*
+                    // 'destroyed' is a valid operation, but the state of the
+                    // VM is actually _not_ changed.
+                    t.equal(res.statusCode, 200);
+                    t.equal(body.state, 'destroyed');
+
+                    return next(err);
+                });
+        }
+    }, function allDone(err) {
+        t.ifError(err);
+        t.done();
+    });
+};
+
+exports.post_on_destroyed_vm_must_fail = function (t) {
+    var UPDATE_VM_ACTIONS = [
+        'start',
+        'stop',
+        'kill',
+        'reboot',
+        'update',
+        'reprovision',
+        'add_nics',
+        'update_nics',
+        'remove_nics',
+        'create_snapshot',
+        'rollback_snapshot',
+        'delete_snapshot'
+    ];
+
+    vasync.forEachParallel({
+        inputs: UPDATE_VM_ACTIONS,
+        func: function (updateVmAction, next) {
+            client.post(vmLocation + '?action=' + updateVmAction, {foo: 'bar'},
+                function (err, req, res, body) {
+                    t.equal(res.statusCode, 409);
+                    var expectedError = {
+                        code: 'ChangingDestroyedVM',
+                        message: 'Invalid operation on a destroyed VM'
+                    };
+                    t.deepEqual(body, expectedError);
+                    return next();
+                });
+        }
+    }, function allDone(err) {
+        t.ifError(err);
+        t.done();
+    });
+};
+
+exports.remove_indestructible_flag_on_destroyed_vm_should_fail = function (t) {
+    client.post(vmLocation + '?action=update&sync=true',
+        {indestructible_zoneroot: false}, function (err, req, res, body) {
+        t.ok(err);
+        t.equal(res.statusCode, 409);
+        var expectedError = {
+            code: 'ChangingDestroyedVM',
+            message: 'Invalid operation on a destroyed VM'
+        };
+        t.deepEqual(body, expectedError);
+        t.done();
+    });
+};

--- a/test/vms.destroy_indestructible_delegated.test.js
+++ b/test/vms.destroy_indestructible_delegated.test.js
@@ -1,0 +1,320 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2015, Joyent, Inc.
+ */
+
+var assert = require('assert-plus');
+var vasync = require('vasync');
+var clone = require('clone');
+var ldapjs = require('ldapjs');
+
+var common = require('../lib/common');
+var testCommon = require('./common');
+var workflow = require('./lib/workflow');
+var vmTest = require('./lib/vm');
+
+var client;
+var MORAY = require('../lib/apis/moray');
+
+var IMAGE = 'fd2cc906-8938-11e3-beab-4359c665ac99';
+var CUSTOMER = testCommon.config.ufdsAdminUuid;
+var NETWORKS = null;
+var SERVER = null;
+
+var VMS_LIST_ENDPOINT = '/vms';
+
+var vmLocation;
+var jobLocation;
+var vmUuid;
+var vmObject;
+var leftoverTestVms = [];
+var leftoverTestVmsDestroyJobUuids = [];
+
+exports.setUp = function (callback) {
+    testCommon.setUp(function (err, _client) {
+        assert.ifError(err);
+        assert.ok(_client, 'restify client');
+        client = _client;
+        callback();
+    });
+};
+
+exports.find_headnode = function (t) {
+    client.cnapi.get('/servers?headnode=true',
+        function (err, req, res, servers) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.ok(servers);
+            t.ok(Array.isArray(servers));
+            for (var i = 0; i < servers.length; i++) {
+                if (servers[i].headnode === true) {
+                    SERVER = servers[i];
+                    break;
+                }
+            }
+            t.ok(SERVER);
+            t.done();
+        });
+};
+
+exports.napi_networks_ok = function (t) {
+    client.napi.get('/networks?provisionable_by=' + CUSTOMER,
+        function (err, req, res, networks) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.ok(networks);
+            t.ok(Array.isArray(networks));
+            t.ok(networks.length > 1);
+            NETWORKS = networks;
+            t.done();
+        });
+};
+
+/*
+ * Fist, delete any leftover VMs from a previous tests run that may not have
+ * been cleaned up properly.
+ */
+exports.get_leftover_test_vms = function (t) {
+    vasync.pipeline({
+        funcs: [
+            function getDestroyingLeftoverVms(args, callback) {
+                client.get(VMS_LIST_ENDPOINT + '?alias=' +
+                    vmTest.TEST_VMS_ALIAS + '&state=destroying',
+                    function (err, req, res, body) {
+                        t.equal(res.statusCode, 200);
+                        t.ok(Array.isArray(body));
+
+                        leftoverTestVms = leftoverTestVms.concat(body);
+                        return callback(err);
+                    });
+            },
+            function getActiveLeftoverVms(args, callback) {
+                client.get(VMS_LIST_ENDPOINT + '?alias=' +
+                    vmTest.TEST_VMS_ALIAS + '&state=active',
+                    function (err, req, res, body) {
+                        t.equal(res.statusCode, 200);
+                        t.ok(Array.isArray(body));
+
+                        leftoverTestVms = leftoverTestVms.concat(body);
+                        return callback(err);
+                    });
+            }
+        ]
+    }, function allDone(err) {
+        t.ifError(err);
+        t.done();
+    });
+};
+
+exports.remove_leftover_test_vms = function (t) {
+    function removeLeftoverVm(testVm, callback) {
+        var testVmLocation = '/vms/' + testVm.uuid;
+        vasync.pipeline({
+            funcs: [
+                function updateIndestructibleFlag(arg, next) {
+                    // First make sure that the indestructible_delegated
+                    // property is false so that we can actually destroy
+                    // this VM.
+                    client.post(testVmLocation + '?action=update&sync=true',
+                        {indestructible_delegated: false},
+                        function (err, req, res, body) {
+                            t.equal(res.statusCode, 202);
+                            return next(err);
+                        });
+                },
+                function removeVm(arg, next) {
+                    // Then actually delete it
+                    client.del(testVmLocation,
+                        function (err, req, res, body) {
+                            t.ifError(err);
+                            t.equal(res.statusCode, 202);
+                            testCommon.checkHeaders(t, res.headers);
+                            t.ok(body);
+                            leftoverTestVmsDestroyJobUuids.push(body.job_uuid);
+
+                            return next();
+                        });
+                }
+            ]
+        }, function done(err) {
+            return callback(err);
+        });
+    }
+
+    vasync.forEachPipeline({
+        inputs: leftoverTestVms,
+        func: removeLeftoverVm
+    }, function allVmsDestroyed(err) {
+        t.ifError(err);
+        t.done();
+    });
+};
+
+exports.wait_for_leftover_vms_to_actually_be_destroyed = function (t) {
+    vasync.forEachParallel({
+        inputs: leftoverTestVmsDestroyJobUuids,
+        func: function (jobUuid, next) {
+            var destroyJobLocation = '/jobs/' + jobUuid;
+            workflow.waitForValue(client, destroyJobLocation, 'execution',
+                'succeeded', next);
+        }
+    }, function allDestroyJobsDone(err) {
+        t.ifError(err);
+        t.done();
+    });
+};
+
+exports.create_indestructible_vm = function (t) {
+    var md = {
+        foo: 'bar',
+        credentials: JSON.stringify({ 'user_pw': '12345678' })
+    };
+
+    var opts = {path: VMS_LIST_ENDPOINT};
+
+    var INDESTRUCTIBLE_VM_PAYLOAD = {
+        owner_uuid: CUSTOMER,
+        image_uuid: IMAGE,
+        server_uuid: SERVER.uuid,
+        networks: [ { uuid: NETWORKS[0].uuid } ],
+        brand: 'joyent-minimal',
+        billing_id: '00000000-0000-0000-0000-000000000000',
+        ram: 64,
+        quota: 10,
+        customer_metadata: md,
+        creator_uuid: CUSTOMER,
+        delegate_dataset: true,
+        indestructible_delegated: true,
+        alias: vmTest.TEST_VMS_ALIAS
+    };
+
+    client.post(opts, INDESTRUCTIBLE_VM_PAYLOAD,
+        function (err, req, res, body) {
+            t.ifError(err);
+            t.equal(res.statusCode, 202);
+            testCommon.checkHeaders(t, res.headers);
+            t.ok(res.headers['workflow-api'], 'workflow-api header');
+            t.ok(body, 'vm ok');
+
+            jobLocation = '/jobs/' + body.job_uuid;
+            vmUuid = body.vm_uuid;
+            vmLocation = '/vms/' + vmUuid;
+            t.done();
+        });
+};
+
+exports.get_job = function (t) {
+    client.get(jobLocation, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200, 'GetJob 200 OK');
+        testCommon.checkHeaders(t, res.headers);
+        t.ok(body, 'job ok');
+        workflow.checkJob(t, body);
+        t.done();
+    });
+};
+
+exports.wait_provisioned_job = function (t) {
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
+};
+
+exports.try_destroy_indestructible_vm = function (t) {
+    client.del(vmLocation, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        testCommon.checkHeaders(t, res.headers);
+        t.ok(body);
+        jobLocation = '/jobs/' + body.job_uuid;
+        t.done();
+    });
+};
+
+exports.wait_destroy_vm_failure = function (t) {
+    workflow.waitForValue(client, jobLocation, 'execution', 'failed',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
+};
+
+exports.update_vmapi_cache_and_check_state = function (t) {
+    client.get(vmLocation + '?sync=true', function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        vmObject = body;
+
+        t.equal(vmObject.state, 'destroyed', 'state should be "destroyed"');
+        t.equal(vmObject.zone_state, 'installed',
+            'zone_state should be "installed"');
+        t.done();
+    });
+};
+
+exports.remove_indestructible_flag = function (t) {
+    client.post(vmLocation + '?action=update&sync=true',
+        {indestructible_delegated: false}, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        t.done();
+    });
+};
+
+exports.check_indestructible_flag_is_removed = function (t) {
+    // Use sync=true here to make sure that the VM's properties
+    // are updated before we test their values.
+    client.get(vmLocation + '?sync=true', function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        vmObject = body;
+
+        t.ok(vmObject.indestructible_delegated === false ||
+            vmObject.indestructible_delegated === undefined,
+            'indestructible_delegated flag should now be set to false');
+        t.done();
+    });
+};
+exports.destroy_destructible_vm = function (t) {
+    var opts = {path: vmLocation};
+
+    client.del(opts, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        testCommon.checkHeaders(t, res.headers);
+        t.ok(body);
+        jobLocation = '/jobs/' + body.job_uuid;
+        t.done();
+    });
+};
+
+exports.wait_destroy_vm_succeeded = function (t) {
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
+};
+
+exports.check_destroyed_vm_state = function (t) {
+    // Use sync=true here to make sure that the VM's properties
+    // are updated before we test their values.
+    client.get(vmLocation + '?sync=true', function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        vmObject = body;
+
+        t.equal(vmObject.state, 'destroyed', 'state should be "destroyed"');
+        t.equal(vmObject.zone_state, 'destroyed',
+            'zone_state should be "destroyed"');
+
+        t.done();
+    });
+};

--- a/test/vms.full.test.js
+++ b/test/vms.full.test.js
@@ -16,6 +16,8 @@ var async = require('async');
 
 var common = require('./common');
 
+var workflow = require('./lib/workflow');
+
 // --- Globals
 
 var client;
@@ -36,10 +38,6 @@ var CALLER = {
     keyId: '/foo@joyent.com/keys/id_rsa'
 };
 
-// In seconds
-var TIMEOUT = 120;
-
-
 // --- Helpers
 
 function checkMachine(t, vm) {
@@ -59,71 +57,6 @@ function checkMachine(t, vm) {
     if (vm.state && vm.state !== 'destroyed') {
         t.ok(vm.quota, 'disk');
     }
-}
-
-
-function checkJob(t, job) {
-    t.ok(job.uuid, 'uuid');
-    t.ok(job.name, 'name');
-    t.ok(job.execution, 'execution');
-    t.ok(job.params, 'params');
-}
-
-
-function checkEqual(value, expected) {
-    if ((typeof (value) === 'object') && (typeof (expected) === 'object')) {
-        var exkeys = Object.keys(expected);
-        for (var i = 0; i < exkeys.length; i++) {
-            var key = exkeys[i];
-            if (value[key] !== expected[key])
-                return false;
-        }
-
-        return true;
-    } else {
-        return (value === expected);
-    }
-}
-
-
-function checkValue(url, key, value, callback) {
-    return client.get(url, function (err, req, res, body) {
-        if (err) {
-            return callback(err);
-        }
-
-        return callback(null, checkEqual(body[key], value));
-    });
-}
-
-
-var times = 0;
-
-function waitForValue(url, key, value, callback) {
-
-    function onReady(err, ready) {
-        if (err) {
-            callback(err);
-            return;
-        }
-
-        if (!ready) {
-            times++;
-
-            if (times == TIMEOUT) {
-                throw new Error('Timeout waiting on ' + url);
-            } else {
-                setTimeout(function () {
-                    waitForValue(url, key, value, callback);
-                }, 1000);
-            }
-        } else {
-            times = 0;
-            callback(null);
-        }
-    }
-
-    return checkValue(url, key, value, onReady);
 }
 
 
@@ -682,17 +615,18 @@ exports.get_job = function (t) {
         t.equal(res.statusCode, 200, 'GetJob 200 OK');
         common.checkHeaders(t, res.headers);
         t.ok(body, 'job ok');
-        checkJob(t, body);
+        workflow.checkJob(t, body);
         t.done();
     });
 };
 
 
 exports.wait_provisioned_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -730,10 +664,11 @@ exports.stop_vm = function (t) {
 
 
 exports.wait_stopped_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -770,10 +705,11 @@ exports.start_vm = function (t) {
 
 
 exports.wait_started_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -809,10 +745,11 @@ exports.reboot_vm = function (t) {
 
 
 exports.wait_rebooted_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -850,10 +787,11 @@ exports.add_nics_with_networks = function (t) {
 
 
 exports.wait_add_nics_with_networks = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -906,10 +844,11 @@ exports.add_nics_with_macs = function (t) {
 
 
 exports.wait_add_nics_with_macs = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -966,10 +905,11 @@ exports.remove_nics = function (t) {
 
 
 exports.wait_remove_nics = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1176,10 +1116,11 @@ exports.add_tags = function (t) {
 
 
 exports.wait_new_tag_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1189,7 +1130,7 @@ exports.wait_new_tag = function (t) {
         group: 'deployment'
     };
 
-    waitForValue(vmLocation, 'tags', tags, function (err) {
+    workflow.waitForValue(client, vmLocation, 'tags', tags, function (err) {
         t.ifError(err);
         t.done();
     });
@@ -1227,10 +1168,11 @@ exports.delete_tag = function (t) {
 
 
 exports.wait_delete_tag_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1239,7 +1181,7 @@ exports.wait_delete_tag = function (t) {
         group: 'deployment'
     };
 
-    waitForValue(vmLocation, 'tags', tags, function (err) {
+    workflow.waitForValue(client, vmLocation, 'tags', tags, function (err) {
         t.ifError(err);
         t.done();
     });
@@ -1263,15 +1205,16 @@ exports.delete_tags = function (t) {
 
 
 exports.wait_delete_tags_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
 exports.wait_delete_tags = function (t) {
-    waitForValue(vmLocation, 'tags', {}, function (err) {
+    workflow.waitForValue(client, vmLocation, 'tags', {}, function (err) {
         t.ifError(err);
         t.done();
     });
@@ -1300,10 +1243,11 @@ exports.set_tags = function (t) {
 
 
 exports.wait_set_tags_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1313,7 +1257,7 @@ exports.wait_set_tags = function (t) {
         group: 'deployment'
     };
 
-    waitForValue(vmLocation, 'tags', tags, function (err) {
+    workflow.waitForValue(client, vmLocation, 'tags', tags, function (err) {
         t.ifError(err);
         t.done();
     });
@@ -1340,10 +1284,11 @@ exports.snapshot_vm = function (t) {
 
 
 exports.wait_snapshot_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1367,10 +1312,11 @@ exports.rollback_vm = function (t) {
 
 
 exports.wait_rollback_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1394,10 +1340,11 @@ exports.delete_snapshot = function (t) {
 
 
 exports.wait_delete_snapshot_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1421,10 +1368,11 @@ exports.reprovision_vm = function (t) {
 
 
 exports.wait_reprovision_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1443,10 +1391,11 @@ exports.destroy_vm = function (t) {
 
 
 exports.wait_destroyed_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1541,17 +1490,18 @@ exports.get_nonautoboot_job = function (t) {
         t.equal(res.statusCode, 200, 'GetJob 200 OK');
         common.checkHeaders(t, res.headers);
         t.ok(body, 'job ok');
-        checkJob(t, body);
+        workflow.checkJob(t, body);
         t.done();
     });
 };
 
 
 exports.wait_nonautoboot_provisioned_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1573,10 +1523,11 @@ exports.change_autoboot = function (t) {
 
 
 exports.wait_autoboot_update_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1610,10 +1561,11 @@ exports.destroy_nonautoboot_vm = function (t) {
 
 
 exports.wait_nonautoboot_destroyed_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1643,10 +1595,11 @@ exports.create_vm_with_package = function (t) {
 
 
 exports.wait_provisioned_with_package_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1731,10 +1684,11 @@ exports.resize_package = function (t) {
 
 
 exports.wait_resize_package_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1769,10 +1723,11 @@ exports.resize_package_down = function (t) {
 
 
 exports.wait_resize_package_job_2 = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1791,10 +1746,11 @@ exports.destroy_vm_with_package = function (t) {
 
 
 exports.wait_destroyed_with_package_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1828,10 +1784,11 @@ exports.provision_network_names = function (t) {
 
 
 exports.wait_provision_network_names = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 
@@ -1961,10 +1918,11 @@ exports.create_docker_vm = function (t) {
 
 
 exports.wait_provisioned_docker_job = function (t) {
-    waitForValue(jobLocation, 'execution', 'succeeded', function (err) {
-        t.ifError(err);
-        t.done();
-    });
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
 };
 
 

--- a/test/vms.list.test.js
+++ b/test/vms.list.test.js
@@ -12,8 +12,11 @@ var assert = require('assert-plus');
 
 var async = require('async');
 
-var common = require('./common');
+var testCommon = require('./common');
+var testListInvalidParams = testCommon.testListInvalidParams;
+var testListValidParams = testCommon.testListValidParams;
 
+var common = require('../lib/common');
 var validation = require('../lib/common/validation');
 var vmTest = require('./lib/vm');
 
@@ -23,10 +26,13 @@ var MORAY = require('../lib/apis/moray');
 var VALID_UUID = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
 var INVALID_UUID = 'invalid_uuid';
 
+var VALID_VM_STATES = common.VALID_VM_STATES;
+var VALID_VM_STATES_ALIASES = common.VALID_VM_STATES_ALIASES;
+
 var MAX_LIMIT = 1000;
 
 exports.setUp = function (callback) {
-    common.setUp(function (err, _client) {
+    testCommon.setUp(function (err, _client) {
         assert.ifError(err);
         assert.ok(_client, 'restify client');
         client = _client;
@@ -44,7 +50,7 @@ exports.list_invalid_param = function (t) {
             message: 'Invalid parameter'
         } ]
     };
-    common.testListInvalidParams(client, {foo: 'bar'}, expectedError, t,
+    testListInvalidParams(client, {foo: 'bar'}, expectedError, t,
         function done() {
             t.done();
         });
@@ -52,7 +58,7 @@ exports.list_invalid_param = function (t) {
 
 var UUID_PARAMS = ['uuid', 'owner_uuid', 'server_uuid', 'image_uuid'];
 
-exports.list_param_invalid_uuids = function (t) {
+exports.list_param_invalid_uuid = function (t) {
     async.each(UUID_PARAMS,
     function (paramName, next) {
         var expectedError = {
@@ -68,8 +74,7 @@ exports.list_param_invalid_uuids = function (t) {
         var invalidParams = {};
         invalidParams[paramName] = INVALID_UUID;
 
-        common.testListInvalidParam(client, invalidParams, expectedError, t,
-            next);
+        testListInvalidParams(client, invalidParams, expectedError, t, next);
     },
     function done(err) {
         t.done();
@@ -82,7 +87,7 @@ exports.list_param_valid_uuid = function (t) {
         var params = {};
         params[paramName] = VALID_UUID;
 
-        common.testListValidParams(client, params, t, next);
+        testListValidParams(client, params, t, next);
     },
     function (err) {
         t.done();
@@ -99,7 +104,7 @@ var VALID_VM_BRANDS = [
 
 exports.list_param_valid_brands = function (t) {
     async.each(VALID_VM_BRANDS, function (vmBrand, next) {
-        common.testListValidParams(client, {brand: vmBrand}, t, next);
+        testListValidParams(client, {brand: vmBrand}, t, next);
     },
     function allDone(err) {
         t.done();
@@ -117,7 +122,7 @@ exports.list_param_invalid_brand = function (t) {
         } ]
     };
 
-    common.testListInvalidParams(client, {brand: 'foobar'}, expectedError, t,
+    testListInvalidParams(client, {brand: 'foobar'}, expectedError, t,
         function testDone() {
             t.done();
         });
@@ -125,7 +130,7 @@ exports.list_param_invalid_brand = function (t) {
 
 exports.list_param_valid_docker = function (t) {
     async.each(['true', 'false'], function (dockerFlag, next) {
-        common.testListValidParams(client, {docker: dockerFlag}, t,
+        testListValidParams(client, {docker: dockerFlag}, t,
             function (err, body) {
                 if (err) {
                     return next(err);
@@ -157,14 +162,14 @@ exports.list_param_invalid_docker = function (t) {
             message: 'Invalid parameter'
         } ]
     };
-    common.testListInvalidParams(client, {docker: 'foobar'}, expectedError, t,
+    testListInvalidParams(client, {docker: 'foobar'}, expectedError, t,
         function testDone() {
             t.done();
         });
 };
 
 exports.list_param_valid_alias = function (t) {
-    common.testListValidParams(client, {alias: 'foo'}, t, function () {
+    testListValidParams(client, {alias: 'foo'}, t, function () {
         t.done();
     });
 };
@@ -183,7 +188,7 @@ exports.list_param_invalid_alias = function (t) {
                 + '/^[a-zA-Z0-9][a-zA-Z0-9\\_\\.\\-]*$/'
             } ]
         };
-        common.testListInvalidParams(client, {alias: invalidAlias},
+        testListInvalidParams(client, {alias: invalidAlias},
             expectedError, t, next);
     },
     function done(err) {
@@ -191,20 +196,14 @@ exports.list_param_invalid_alias = function (t) {
     });
 };
 
-var VALID_VM_STATES = [
-    'running',
-    'stopped',
-    'active',
-    'destroyed'
-];
-
 exports.list_param_valid_state = function (t) {
-    async.each(VALID_VM_STATES, function (vmState, next) {
-        common.testListValidParams(client, {state: vmState}, t, next);
-    },
-    function allDone(err) {
-        t.done();
-    });
+    async.each(VALID_VM_STATES.concat(VALID_VM_STATES_ALIASES),
+        function (vmState, next) {
+            testListValidParams(client, {state: vmState}, t, next);
+        },
+        function allDone(err) {
+            t.done();
+        });
 };
 
 exports.list_param_invalid_state = function (t) {
@@ -214,10 +213,11 @@ exports.list_param_invalid_state = function (t) {
         errors: [ {
             field: 'state',
             code: 'Invalid',
-            message: 'Must be one of: ' + VALID_VM_STATES.join(', ')
+            message: 'Must be one of: ' +
+                VALID_VM_STATES.concat(VALID_VM_STATES_ALIASES).join(', ')
         } ]
     };
-    common.testListInvalidParams(client, {state: 'foobar'}, expectedError, t,
+    testListInvalidParams(client, {state: 'foobar'}, expectedError, t,
         function testDone() {
             t.done();
         });
@@ -225,7 +225,7 @@ exports.list_param_invalid_state = function (t) {
 
 exports.list_param_valid_ram = function (t) {
     async.each(['1', '128', '2048'], function (ram, next) {
-        common.testListValidParams(client, {ram: ram}, t, next);
+        testListValidParams(client, {ram: ram}, t, next);
     },
     function allDone(err) {
         t.done();
@@ -244,7 +244,7 @@ exports.list_param_invalid_ram = function (t) {
                 message: 'String does not match regexp: /^0$|^([1-9][0-9]*$)/'
             } ]
         };
-        common.testListInvalidParams(client, {ram: invalidRam}, expectedError,
+        testListInvalidParams(client, {ram: invalidRam}, expectedError,
             t, next);
     },
     function done(err) {
@@ -257,7 +257,7 @@ exports.list_param_valid_uuids = function (t) {
         [VALID_UUID].join(','),
         [VALID_UUID, VALID_UUID].join(',')
     ], function (uuids, next) {
-        common.testListValidParams(client, {uuids: uuids}, t, next);
+        testListValidParams(client, {uuids: uuids}, t, next);
     },
     function allDone(err) {
         t.done();
@@ -279,7 +279,7 @@ exports.list_param_invalid_uuids = function (t) {
                 message: 'Invalid values: ' + invalidUuids
             } ]
         };
-        common.testListInvalidParams(client, {uuids: invalidUuids},
+        testListInvalidParams(client, {uuids: invalidUuids},
             expectedError, t, next);
     },
     function allDone(err) {
@@ -309,7 +309,7 @@ function testValidLimit(limit, t, callback) {
         EXPECTED_NB_VMS_RETURNED = NB_TEST_VMS_TO_CREATE;
     }
 
-    var moray = new MORAY(common.config.moray);
+    var moray = new MORAY(testCommon.config.moray);
     moray.connect();
 
     moray.once('moray-ready', function () {
@@ -380,7 +380,7 @@ exports.list_vms_valid_limit = function (t) {
  * (list_vms_valid_limit).
  */
 exports.delete_list_vms_valid_limit = function (t) {
-    var moray = new MORAY(common.config.moray);
+    var moray = new MORAY(testCommon.config.moray);
     moray.connect();
 
     moray.once('moray-ready', function () {
@@ -397,7 +397,7 @@ exports.list_param_valid_create_timestamp = function (t) {
         new Date().getTime(),
         new Date().toISOString()
     ], function (validTimestamp, next) {
-        common.testListValidParams(client, {create_timestamp: validTimestamp},
+        testListValidParams(client, {create_timestamp: validTimestamp},
             t, next);
     }, function allDone(err) {
         t.done();
@@ -419,8 +419,8 @@ exports.list_param_invalid_create_timestamp = function (t) {
                 message: 'Invalid timestamp: ' + invalidTimestamp
             } ]
         };
-        common.testListInvalidParams(client,
-            {create_timestamp: invalidTimestamp}, expectedError, t, next);
+        testListInvalidParams(client, {create_timestamp: invalidTimestamp},
+            expectedError, t, next);
     }, function allDone(err) {
         t.done();
     });
@@ -439,7 +439,7 @@ exports.list_param_valid_vm_fields = function (t) {
 
     async.each(validVmFieldsList,
         function (validVmFields, next) {
-            common.testListValidParams(client, {fields: validVmFields}, t,
+            testListValidParams(client, {fields: validVmFields}, t,
                 next);
         },
         function allDone(err) {
@@ -463,8 +463,8 @@ exports.list_param_invalid_vm_fields = function (t) {
                 message: 'Invalid values: ' + invalidVmFields
             } ]
         };
-        common.testListInvalidParams(client, {fields: invalidVmFields},
-            expectedError, t, next);
+        testListInvalidParams(client, {fields: invalidVmFields}, expectedError,
+            t, next);
     }, function allDone(err) {
         t.done();
     });
@@ -473,7 +473,7 @@ exports.list_param_invalid_vm_fields = function (t) {
 exports.list_param_valid_limit = function (t) {
     async.each([1, 500, MAX_LIMIT],
         function (validLimit, next) {
-            common.testListValidParams(client, {limit: validLimit}, t, next);
+            testListValidParams(client, {limit: validLimit}, t, next);
         },
         function allDone(err) {
             t.done();
@@ -492,7 +492,7 @@ exports.list_param_invalid_limit = function (t) {
                     MAX_LIMIT
             } ]
         };
-        common.testListInvalidParams(client, {limit: invalidLimit},
+        testListInvalidParams(client, {limit: invalidLimit},
             expectedError, t, next);
     }, function allDone(err) {
         t.done();
@@ -501,7 +501,7 @@ exports.list_param_invalid_limit = function (t) {
 
 exports.list_param_valid_offset = function (t) {
     async.each([0, 1, 500], function (validOffset, next) {
-        common.testListValidParams(client, {offset: validOffset}, t, next);
+        testListValidParams(client, {offset: validOffset}, t, next);
     }, function allDone(err) {
         t.done();
     });
@@ -518,7 +518,7 @@ exports.list_param_invalid_offset = function (t) {
                 message: 'Not a valid number: number must be >= 0'
             } ]
         };
-        common.testListInvalidParams(client, {offset: invalidOffset},
+        testListInvalidParams(client, {offset: invalidOffset},
             expectedError, t, next);
     }, function allDone(err) {
         t.done();

--- a/test/vms.put_many_invalid_state_change.test.js
+++ b/test/vms.put_many_invalid_state_change.test.js
@@ -1,0 +1,286 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2015, Joyent, Inc.
+ */
+
+// The first part of this test creates a large number of VMs with
+// state === 'destroyed', and then attempts to change their state to 'running'
+// with a PUT /vms request.
+// Changing the state of a VM from state === 'destroyed' to any state that is
+// !== 'destroyed' is an invalid transition. However, it should not result in a
+// request failure, instead the state change should be overriden and all VMs
+// should still be 'destroyed' after the PUT /vms request.
+//
+// The second part of this test also test invalid transitions for the
+// zone_state property. It creates test VMs with zone_state === 'destroyed'
+// and attempts to change their zone_state property with PUT /vms to a
+// non-destroyed state. It is also an invalid transition, but instead of being
+// silently overriden, it is considered as an error. Thus, the test makes
+// sure that this request results in an error.
+
+var path = require('path');
+var fs = require('fs');
+
+var bunyan = require('bunyan');
+var restify = require('restify');
+var assert = require('assert-plus');
+var vasync = require('vasync');
+
+var testVm = require('../test/lib/vm');
+var testCommon = require('./common');
+var configFileLoader = require('../lib/config-loader');
+
+var MORAY = require('../lib/apis/moray');
+var VMS_LIST_ENDPOINT = '/vms';
+// Use a large number of VMs so that the test requires to fetch several "pages"
+// of data from VMAPI, and even when interacting with moray. The current
+// default limit for VMAPI and moray's server being 1000 entries per page,
+// so 1001 test VMs forces this test to do paginated reads from both of these
+// components.
+var NB_TEST_VMS = 1001;
+
+var CONFIG = configFileLoader.loadConfig();
+
+CONFIG.moray.reconnect = true;
+CONFIG.moray.retry = {retries: Infinity, minTimeout: 500, maxTimeout: 2000};
+var MORAY_CLIENT = new MORAY(CONFIG.moray);
+
+var client;
+var SERVER;
+
+function createTestVms(nbTestVms, morayClient, params, cb) {
+    assert.number(nbTestVms, 'nbTestVms must be a number');
+    assert.object(morayClient, 'morayClient must be an object');
+    assert.object(params, 'params must be an object');
+    assert.func(cb, 'cb must be a function');
+
+    morayClient.connect();
+    morayClient.once('moray-ready', function () {
+        testVm.createTestVMs(NB_TEST_VMS, morayClient, {},
+            params, function allVmsCreated(err) {
+                morayClient.connection.close();
+                return cb(err);
+            });
+    });
+}
+
+function removeTestVms(morayClient, cb) {
+    assert.object(morayClient, 'morayClient must be an object');
+    assert.func(cb, 'cb must be a function');
+
+    morayClient.connect();
+    morayClient.once('moray-ready', function () {
+        testVm.deleteTestVMs(morayClient, {}, function allVmsDeleted(err) {
+            morayClient.connection.close();
+            return cb(err);
+        });
+    });
+}
+
+exports.setUp = function (callback) {
+    testCommon.setUp(function (err, _client) {
+        assert.ifError(err);
+        assert.ok(_client, 'restify client');
+        client = _client;
+        callback();
+    });
+};
+
+exports.find_headnode = function (t) {
+    client.cnapi.get('/servers?headnode=true',
+        function (err, req, res, servers) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200);
+            t.ok(servers);
+            t.ok(Array.isArray(servers));
+            for (var i = 0; i < servers.length; i++) {
+                if (servers[i].headnode === true) {
+                    SERVER = servers[i];
+                    break;
+                }
+            }
+            t.ok(SERVER);
+            t.done();
+        });
+};
+
+exports.cleanup_leftover_test_vms = function (t) {
+    removeTestVms(MORAY_CLIENT, function vmsRemoved(err) {
+        t.done();
+        return;
+    });
+};
+
+exports.create_state_destroyed_test_vms = function (t) {
+    createTestVms(NB_TEST_VMS, MORAY_CLIENT, {
+        state: 'destroyed',
+        zone_state: 'installed',
+        server_uuid: SERVER.uuid
+    }, function testVmsCreated() {
+        t.done();
+    });
+};
+
+exports.change_destroyed_test_vms_state = function (t) {
+    vasync.waterfall([
+        function getVms(next) {
+            client.sdcClient.listVms({alias: testVm.TEST_VMS_ALIAS},
+                function (err, vms) {
+                    var allVmsDestroyed = false;
+
+                    t.ifError(err, 'the response should not be an error');
+                    t.ok(Array.isArray(vms),
+                        'the response body should be an array');
+                    t.equal(vms.length, NB_TEST_VMS, 'there should be ' +
+                        NB_TEST_VMS + ' objects in the response');
+
+                    allVmsDestroyed = vms.every(function checkVmState(vm) {
+                        return vm.state === 'destroyed';
+                    });
+
+                    t.equal(allVmsDestroyed, true,
+                        'All test VMs should have their state set to ' +
+                        '\'destroyed\'');
+
+                    next(err, vms);
+                    return;
+                });
+        },
+        function changeAllVmsState(vms, next) {
+            var vmsPayload = {};
+            vms.forEach(function changeVmState(vm) {
+                var vmWithStateChanged = vm;
+                vmWithStateChanged.state = 'running';
+                vmsPayload[vm.uuid] = vmWithStateChanged;
+            });
+
+            client.put('/vms?server_uuid=' + SERVER.uuid, {vms: vmsPayload},
+                function (err, req, res, body) {
+                    t.equal(res.statusCode, 200,
+                        'changing VMs state should succeed');
+                    return next(err);
+                });
+        },
+        function checkVmsState(next) {
+            client.sdcClient.listVms({alias: testVm.TEST_VMS_ALIAS},
+                function (err, vms) {
+                    var allVmsDestroyed = false;
+
+                    t.ok(Array.isArray(vms),
+                        'the response body should be an array');
+                    t.equal(vms.length, NB_TEST_VMS, 'there should be ' +
+                        NB_TEST_VMS + ' objects in the response');
+                    console.log('vms:', vms);
+                    allVmsDestroyed = vms.every(function checkVmState(vm) {
+                        return vm.state === 'destroyed';
+                    });
+                    t.equal(allVmsDestroyed, true,
+                        'All test VMs should have their state set to ' +
+                        '\'destroyed\'');
+
+                    next(err);
+                    return;
+                });
+        }
+    ], function changeTestVmsDone(err, results) {
+        t.ifError(err);
+        t.done();
+        return;
+    });
+};
+
+exports.cleanup_state_destroyed_test_vms = function (t) {
+    removeTestVms(MORAY_CLIENT, function vmsRemoved(err) {
+        t.done();
+        return;
+    });
+};
+
+exports.create_zone_state_destroyed_test_vms = function (t) {
+    createTestVms(NB_TEST_VMS, MORAY_CLIENT, {
+        state: 'destroyed',
+        zone_state: 'destroyed',
+        server_uuid: SERVER.uuid
+    }, function testVmsCreated() {
+        t.done();
+    });
+};
+
+exports.change_destroyed_test_vms_zone_state = function (t) {
+    vasync.waterfall([
+        function getVms(next) {
+            client.sdcClient.listVms({alias: testVm.TEST_VMS_ALIAS},
+                function (err, vms) {
+                    var allVmsDestroyed = false;
+
+                    t.ifError(err);
+                    t.ok(Array.isArray(vms));
+                    t.equal(vms.length, NB_TEST_VMS);
+
+                    allVmsDestroyed = vms.every(function checkVmState(vm) {
+                        return vm.zone_state === 'destroyed' &&
+                            vm.zone_state === 'destroyed';
+                    });
+
+                    t.equal(allVmsDestroyed, true,
+                        'All test VMs should have their state and zone_state '+
+                            'set to \'destroyed\'');
+
+                    next(err, vms);
+                    return;
+                });
+        },
+        function changeAllVmsZoneState(vms, next) {
+            var vmsPayload = {};
+            vms.forEach(function changeVmState(vm) {
+                var vmWithZoneStateChanged = vm;
+                vmWithZoneStateChanged.zone_state = 'installed';
+                vmsPayload[vm.uuid] = vmWithZoneStateChanged;
+            });
+
+            client.put('/vms?server_uuid=' + SERVER.uuid, {vms: vmsPayload},
+                function (err, req, res, body) {
+                    t.ok(err);
+                    t.equal(res.statusCode, 409,
+                        'changing VMs zone_state should fail');
+                    return next();
+                });
+        },
+        function checkVmsState(next) {
+            client.sdcClient.listVms({alias: testVm.TEST_VMS_ALIAS},
+                function (err, vms) {
+                    var allVmsDestroyed = false;
+
+                    t.ok(Array.isArray(vms));
+                    t.equal(vms.length, NB_TEST_VMS);
+
+                    allVmsDestroyed = vms.every(function checkVmState(vm) {
+                        return vm.state === 'destroyed' &&
+                            vm.zone_state === 'destroyed';
+                    });
+                    t.equal(allVmsDestroyed, true,
+                        'All test VMs should have their state and ' +
+                        'zone_state set to \'destroyed\'');
+
+                    next(err);
+                    return;
+                });
+        }
+    ], function changeTestVmsDone(err, results) {
+        t.ifError(err);
+        t.done();
+        return;
+    });
+};
+
+exports.cleanup_zone_state_destroyed_test_vms = function (t) {
+    removeTestVms(MORAY_CLIENT, function vmsRemoved(err) {
+        t.done();
+        return;
+    });
+};

--- a/test/vms.state_manual_override.test.js
+++ b/test/vms.state_manual_override.test.js
@@ -1,0 +1,136 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2015, Joyent, Inc.
+ */
+
+// This test tests the 'manual_override' state. It makes sure that all
+// transitions from/to state === 'destroyed' that are valid per the
+// documentation do not result in an error, and that all transitions that are
+// invalid result in an error.
+
+var assert = require('assert-plus');
+var vasync = require('vasync');
+var clone = require('clone');
+
+var common = require('../lib/common');
+var testCommon = require('./common');
+var workflow = require('./lib/workflow');
+var vmTest = require('./lib/vm');
+var configFileLoader = require('../lib/config-loader');
+var MORAY = require('../lib/apis/moray');
+
+var testVm = require('../test/lib/vm');
+
+var client;
+
+var VMS_LIST_ENDPOINT = '/vms';
+
+var vmLocation;
+var vmObject;
+
+var CONFIG = configFileLoader.loadConfig();
+
+CONFIG.moray.reconnect = true;
+CONFIG.moray.retry = {retries: Infinity, minTimeout: 500, maxTimeout: 2000};
+var morayClient = new MORAY(CONFIG.moray);
+
+exports.setUp = function (callback) {
+    testCommon.setUp(function (err, _client) {
+        assert.ifError(err);
+        assert.ok(_client, 'restify client');
+        client = _client;
+        callback();
+    });
+};
+
+exports.cleanup_leftover_test_vms = function (t) {
+    morayClient.connect();
+    morayClient.once('moray-ready', function () {
+        testVm.deleteTestVMs(morayClient, {}, function allVmsDeleted(err) {
+            morayClient.connection.close();
+            t.done();
+        });
+    });
+};
+
+exports.create_state_destroyed_test_vm = function (t) {
+    morayClient.connect();
+    morayClient.once('moray-ready', function () {
+        testVm.createTestVMs(1, morayClient, {}, {state: 'destroyed'},
+            function allVmsCreated(err, testVmsUuid) {
+                morayClient.connection.close();
+                t.ifError(err);
+                t.ok(Array.isArray(testVmsUuid) && testVmsUuid.length === 1);
+                vmLocation = VMS_LIST_ENDPOINT + '/' + testVmsUuid[0];
+                t.done();
+            });
+    });
+};
+
+exports.check_destroyed_vm_state = function (t) {
+    // Use sync=true here to make sure that the VM's properties
+    // are updated before we test their values.
+    client.get(vmLocation + '?sync=true', function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        vmObject = body;
+
+        t.equal(vmObject.state, 'destroyed', 'state should be "destroyed"');
+        t.equal(vmObject.zone_state, 'destroyed',
+            'zone_state should be "destroyed"');
+
+        t.done();
+    });
+};
+
+exports.any_state_to_and_from_manual_override_ok = function (t) {
+    vasync.forEachPipeline({
+        func: function testTransition(vmState, cb) {
+            vasync.pipeline({
+                funcs: [
+                    function setManualOverrideState(args, next) {
+                        var vmInNewState = clone(vmObject);
+                        vmInNewState.state = 'manual_override';
+                        client.put(vmLocation, vmInNewState,
+                            function (err, req, res, body) {
+                                t.equal(res.statusCode, 200,
+                                    'setting state manual_override must ' +
+                                    'always succeed');
+                                t.equal(body.state, 'manual_override',
+                                    'VM state must then be ' +
+                                    '\'manual_override\'');
+
+                                return next(err);
+                            });
+                    },
+                    function setState(args, next) {
+                        var vmInNewState = clone(vmObject);
+                        vmInNewState.state = vmState;
+                        client.put(vmLocation, vmInNewState,
+                            function (err, req, res, body) {
+                                t.equal(res.statusCode, 200,
+                                    'Setting a VM to state \'' + vmState +
+                                    '\' from state === \'manual_override\' ' +
+                                    'must succeed');
+                                t.equal(body.state, vmState, 'VM state must ' +
+                                    'then be \'' + vmState + '\'');
+
+                                return next(err);
+                            });
+                    }
+                ]
+            }, function testTransitionDone(err, results) {
+                return cb(err);
+            });
+        },
+        inputs: common.VALID_VM_STATES
+    }, function testDone(err, results) {
+        t.ifError(err);
+        t.done();
+    });
+};

--- a/tools/migrations/add-docker-index.js
+++ b/tools/migrations/add-docker-index.js
@@ -8,38 +8,15 @@
  * Copyright (c) 2014, Joyent, Inc.
  */
 
-// Backfill image_uuid for KVM VMs
-var path = require('path');
-var fs = require('fs');
-var util = require('util');
-
 var bunyan = require('bunyan');
 var restify = require('restify');
-var moray = require('moray');
-var async = require('async');
-var levels = [bunyan.TRACE, bunyan.DEBUG, bunyan.INFO,
-              bunyan.WARN, bunyan.ERROR, bunyan.FATAL];
-var config;
+
+var configLoader = require('../../lib/config-loader');
+var MORAY = require('../../lib/apis/moray.js');
+
 var log;
 
-
-/*
- * Loads and parse the configuration file at config.json
- */
-function loadConfig() {
-    var configPath = path.join(__dirname, '..', '..', 'config.json');
-
-    if (!fs.existsSync(configPath)) {
-        console.error('Config file not found: ' + configPath +
-          ' does not exist. Aborting.');
-        process.exit(1);
-    }
-
-    var theConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    return theConfig;
-}
-
-var config = loadConfig();
+var config = configLoader.loadConfig();
 console.log(config);
 
 log = new bunyan({
@@ -48,73 +25,19 @@ log = new bunyan({
     serializers: restify.bunyan.serializers
 });
 
+var moray = new MORAY(config.moray);
+moray.connect();
 
-var BUCKET = {
-    name: 'vmapi_vms',
-    index: {
-        uuid: { type: 'string', unique: true},
-        owner_uuid: { type: 'string' },
-        image_uuid: { type: 'string' },
-        billing_id: { type: 'string' },
-        server_uuid: { type: 'string' },
-        package_name: { type: 'string' },
-        package_version: { type: 'string' },
-        tags: { type: 'string' },
-        brand: { type: 'string' },
-        state: { type: 'string' },
-        alias: { type: 'string' },
-        max_physical_memory: { type: 'number' },
-        create_timestamp: { type: 'number' },
-        docker: { type: 'boolean' }
-    }
-};
+moray.once('moray-ready', function onConnectedToMoray() {
+    moray.addVmIndex({name: 'docker', type: 'string'},
+        function (err) {
+        if (err) {
+            console.error(err);
+            process.exit(1);
+            return;
+        }
 
-function getMorayClient(callback) {
-    var client = moray.createClient({
-        connectTimeout: config.moray.connectTimeout || 200,
-        host: config.moray.host,
-        port: config.moray.port,
-        log: log,
-        reconnect: true,
-        retry: (config.moray.retry === false ? false : {
-            retries: Infinity,
-            minTimeout: 1000,
-            maxTimeout: 16000
-        })
+        log.info('"docker" index has been successfully added');
+         moray.connection.close();
     });
-
-    client.on('connect', function () {
-        return callback(client);
-    });
-}
-
-function updateBucket(callback) {
-    getMorayClient(function (mclient) {
-        morayClient = mclient;
-        morayClient.getBucket(BUCKET.name, function (err, bck) {
-            if (err) {
-                return callback(err);
-            } else if (bck.index.docker !== undefined) {
-                log.info('"docker" index already exists, no need to add');
-                return callback();
-            }
-
-            log.info('adding "docker" index');
-            morayClient.updateBucket(BUCKET.name, { index: BUCKET.index },
-                callback);
-        });
-    });
-}
-
-
-updateBucket(function (updateErr) {
-    if (updateErr) {
-        console.error(updateErr.toString());
-        process.exit(1);
-        return;
-    }
-
-    log.info('"docker" index has been successfully added');
-    process.exit(0);
 });
-

--- a/tools/remove-vm-index.js
+++ b/tools/remove-vm-index.js
@@ -1,0 +1,64 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2015, Joyent, Inc.
+ */
+
+ var vasync = require('vasync');
+
+ if (process.argv.length !== 3) {
+    usage();
+} else {
+    removeVmIndex(process.argv[2]);
+}
+
+function usage() {
+    console.log('usage: node remove-vm-index.js index-name');
+    process.exit(1);
+}
+
+function removeVmIndex(indexName) {
+    var bunyan = require('bunyan');
+    var restify = require('restify');
+
+    var configLoader = require('../lib/config-loader');
+    var MORAY = require('../lib/apis/moray.js');
+
+    var log;
+
+    var config = configLoader.loadConfig();
+    console.log(config);
+
+    log = new bunyan({
+       name: 'remove-index',
+       level: config.logLevel || 'debug',
+       serializers: restify.bunyan.serializers
+    });
+
+    var moray = new MORAY(config.moray);
+    moray.connect();
+
+    moray.once('moray-ready', function onConnectedToMoray() {
+       vasync.pipeline({
+          funcs: [
+            function removeIndex(arg, next) {
+                moray.removeVmIndex(indexName, next);
+            },
+            function reindexVms(arg, next) {
+                moray.reindexVms(next);
+            }
+        ]
+        }, function allDone(err, results) {
+          log.info('index "' + indexName +
+              '"" has been successfully removed');
+          moray.connection.close();
+        });
+    });
+}
+
+
+


### PR DESCRIPTION
Do not wait until a VM is actually destroyed/deleted to return from a
DELETE /vms/vm_uuid request. Instead, stop the VM and at that point, do
not allow any change to this VM except for marking it as destroyed when
it's actually been destroyed.

This change also adds versioning to the current vmapi_vms bucket so that
it indexes the newly added 'zone_state' index required to be able to
search for VMs with `state === 'destroyed' && zone_state !== 'destroyed'`
when looking for "destroying" VMs.