### PR TITLE
ZAPI-685: do not start a workflow on DELETE /vms if not needed

### DIFF
--- a/lib/endpoints/vms.js
+++ b/lib/endpoints/vms.js
@@ -12,11 +12,13 @@
  * This contains the /vms endpoint handlers.
  */
 
+var util = require('util');
+
 var async = require('async');
+var vasync = require('vasync');
 var assert = require('assert-plus');
 var deepDiff = require('deep-diff');
 var restify = require('restify');
-var util = require('util');
 
 var common = require('../common');
 var errors = require('../errors');
@@ -765,14 +767,20 @@ function removeNics(req, res, next) {
 }
 
 
-
 /*
  * Deletes a vm
  */
 function deleteVm(req, res, next) {
+    assert.object(req.vm, 'req.vm must be an object');
+
     var sync = req.params.sync;
 
     req.log.trace({ vm_uuid: req.params.uuid }, 'DeleteVm start');
+
+    if (req.vm.state === 'provisioning') {
+        return next(new restify.errors.ConflictError('Cannot delete a VM ' +
+            'when it is provisioning'));
+    }
 
     if (sync && ['true', 'false'].indexOf(sync) === -1) {
         var error = [ errors.invalidParamErr('sync') ];
@@ -782,15 +790,87 @@ function deleteVm(req, res, next) {
         req.params.sync = (sync === 'true' ? true : false);
     }
 
-    return req.app.wfapi.createDestroyJob(req, function (err, juuid) {
-        if (err) {
-            return next(err);
-        }
+    // If the vm has no server_uuid and unless it's provisioning, then starting
+    // a destroy workflow would fail right after it starts, since there's
+    // nothing to delete on any CN. In this case, instead of taking some space
+    // in the workflow's queue (slowing down any other worfklow) and waiting
+    // for the workflow to fail, just mark the VM as destroyed in moray.
+    // It's faster, and uses far less resources of the overall system.
+    if (req.vm.server_uuid === undefined || req.vm.server_uuid === null) {
+        _destroyVm(req.vm, {
+            publisher: req.app.publisher,
+            moray: req.app.moray
+        }, function (err, destroyedVm) {
+            if (err) {
+                return next(err);
+            }
 
-        return handleUpdateVMResponse(req, res, next, juuid);
-    });
+            res.send(200, destroyedVm);
+            return next();
+        });
+    } else {
+        req.app.cnapi.getServer(req.vm.server_uuid,
+            function onGetServer(err, server) {
+                var serverNotFoundError = _cnapiServerNotFoundError(err);
+                if (err && !serverNotFoundError) {
+                    return next(err);
+                }
+
+                if (serverNotFoundError) {
+                    _destroyVm(req.vm, {
+                        publisher: req.app.publisher,
+                        moray: req.app.moray
+                    }, function (destroyErr, destroyedVm) {
+                        if (destroyErr) {
+                            return next(err);
+                        }
+
+                        res.send(200, destroyedVm);
+                        return next();
+                    });
+                } else {
+                    return req.app.wfapi.createDestroyJob(req,
+                        function (jobErr, juuid) {
+                            if (jobErr) {
+                                return next(jobErr);
+                            }
+
+                            return handleUpdateVMResponse(req, res, next,
+                                juuid);
+                        });
+                }
+            });
+    }
 }
 
+function _cnapiServerNotFoundError(err) {
+    return err && err.body && err.body.code === 'ResourceNotFound';
+}
+
+function _destroyVm(vm, options, cb) {
+    assert.object(vm, 'vm must be an object');
+    assert.object(options, 'options must be an object');
+    assert.object(options.publisher, 'publisher must be an object');
+    assert.object(options.moray, 'moray must be an object');
+    assert.func(cb, 'cb must be a function');
+
+    vasync.waterfall([
+        function markVmAsDestroyed(next) {
+            options.moray.markAsDestroyed(vm, next);
+        },
+        function publishVmChange(destroyedVm, next) {
+            common.publishChange(options.publisher, VM,
+                [destroyedVm.state], destroyedVm.uuid,
+                function onChangePublished(err) {
+                    next(err, destroyedVm);
+                    return;
+                });
+        }
+    ], function vmDestroyed(err, destroyedVm) {
+        cb(err, destroyedVm);
+        return;
+    });
+}
 
 
 /*
@@ -1121,14 +1201,10 @@ function putVm(req, res, next) {
     var publisher = req.app.publisher;
 
     if (vm.state === 'destroyed') {
-        async.waterfall([
-            function _destroyVm(cb) {
-                req.app.moray.markAsDestroyed(vm, cb);
-            },
-            function _pub(obj, cb) {
-                common.publishChange(publisher, VM, [vm.state], vm.uuid, cb);
-            }
-        ], function waterfallEnd(err) {
+        _destroyVm(vm, {
+            publisher: req.app.publisher,
+            moray: req.app.moray
+        }, function vmDestroyed(err, destroyedVm) {
             if (err) {
                 return next(err);
             }

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "assert-plus": "0.1.0",
     "async": "0.2.6",
     "bunyan": "1.3.4",
-    "jsprim": "^1.2.2",
-    "ldapjs": "^1.0.0",
     "changefeed": "1.0.5",
     "deep-diff": "0.3.3",
     "effluent-logger": "git+https://github.com/joshwilsdon/effluent-logger.git#d662f161a07f94045ad2afb45442931511c40e51",
     "filed": "0.0.5",
+    "jsprim": "^1.2.2",
+    "ldapjs": "^1.0.0",
     "libuuid": "0.1.2",
     "moray": "git+ssh://git@github.com:joyent/node-moray.git#b84ef0e",
     "nodeunit": "0.9.1",
@@ -22,6 +22,7 @@
     "sigyan": "0.2.0",
     "sprintf": "0.1.1",
     "trace-event": "1.3.0",
+    "vasync": "^1.6.3",
     "wf-client": "git+ssh://git@github.com:joyent/sdc-wf-client.git#469fc74"
   },
   "sdcDependencies": {

--- a/test/vms.delete_non_existing_no_workflow.test.js
+++ b/test/vms.delete_non_existing_no_workflow.test.js
@@ -1,0 +1,127 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2015, Joyent, Inc.
+ */
+
+// The goal of this test is to make sure that, when sending a DELETE request
+// for a VM that has no server_uuid, or for which the server_uuid does not
+// represent a CN that actually exists, a destroy workflow is not started and
+// instead the VM's state is set to destroyed immediately.
+
+var libuuid = require('libuuid');
+var assert = require('assert-plus');
+
+var common = require('./common');
+var vmTest = require('./lib/vm');
+var moray = require('../lib/apis/moray');
+
+var client;
+var TEST_VM_UUID = libuuid.create();
+var NON_EXISTING_CN_UUID = libuuid.create();
+
+exports.setUp = function (callback) {
+    common.setUp(function (err, _client) {
+        assert.ifError(err);
+        assert.ok(_client, 'restify client');
+        client = _client;
+        callback();
+    });
+};
+
+exports.create_vm_with_null_server_uuid = function (t) {
+    client.put('/vms/' + TEST_VM_UUID, {
+        uuid: TEST_VM_UUID,
+        alias: vmTest.TEST_VMS_ALIAS,
+        state: 'running'
+    }, function onPutDone(err, req, res, newVm) {
+        t.ifError(err, 'The test VM should be created succesfully');
+        t.ok(newVm, 'The response should contain a VM object');
+        t.equal(newVm.server_uuid, null,
+            'The server_uuid property of the test VM should be null');
+        t.done();
+    });
+};
+
+exports.delete_vm_with_null_server_uuid = function (t) {
+    client.del('/vms/' + TEST_VM_UUID,
+        function onVmDeleted(err, req, res, body) {
+            t.ifError(err);
+            t.equal(body.state, 'destroyed',
+                'The response body should have a state set to destroyed');
+            t.equal(body.job_uuid, undefined,
+                'The response body should not have a job uuid');
+            t.done();
+        });
+};
+
+exports.create_vm_on_non_existing_server_uuid = function (t) {
+    client.put('/vms/' + TEST_VM_UUID, {
+        uuid: TEST_VM_UUID,
+        server_uuid: NON_EXISTING_CN_UUID,
+        alias: vmTest.TEST_VMS_ALIAS,
+        state: 'running'
+    }, function onPutDone(err, req, res, newVm) {
+        t.ifError(err, 'The test VM should be created succesfully');
+        t.ok(newVm, 'The response should contain a VM object');
+        t.equal(newVm.server_uuid, NON_EXISTING_CN_UUID,
+            'The server_uuid property of the test VM should be the uuid of ' +
+            'the non-existing CN');
+        t.done();
+    });
+};
+
+exports.delete_vm_on_non_existing_server_uuid = function (t) {
+    client.del('/vms/' + TEST_VM_UUID,
+        function onVmDeleted(err, req, res, body) {
+            t.ifError(err);
+            t.equal(body.state, 'destroyed',
+                'The response body should have a state set to destroyed');
+            t.equal(body.job_uuid, undefined,
+                'The response body should not have a job uuid');
+            t.done();
+        });
+};
+
+exports.create_provisioning_vm = function (t) {
+    client.put('/vms/' + TEST_VM_UUID, {
+        uuid: TEST_VM_UUID,
+        alias: vmTest.TEST_VMS_ALIAS,
+        state: 'provisioning'
+    }, function onPutDone(err, req, res, newVm) {
+        t.ifError(err, 'The test VM should be created succesfully');
+        t.ok(newVm, 'The response should contain a VM object');
+        t.equal(newVm.server_uuid, null,
+            'The server_uuid property of the test VM should be null');
+        t.equal(newVm.state, 'provisioning',
+            'The new VM should be in the provisioning state');
+        t.done();
+    });
+};
+
+exports.delete_provisioning_vm = function (t) {
+    client.del('/vms/' + TEST_VM_UUID,
+        function onVmDeleted(err, req, res, body) {
+            t.ok(err);
+            t.equal(res.statusCode, 409,
+                'The server should respond with a 409 HTTP status code');
+            t.done();
+        });
+};
+
+exports.cleanup_test_vms = function (t) {
+    var morayClient = new moray(common.config.moray);
+    morayClient.connect();
+
+    morayClient.once('moray-ready', function () {
+        vmTest.deleteTestVMs(morayClient, {}, function testVmDeleted(err) {
+            morayClient.connection.close();
+            t.ifError(err, 'Deleting the test VM should not error');
+            t.done();
+        });
+    });
+};


### PR DESCRIPTION
When handling a DELETE /vms/some-vm request, do not start a workflow if
one of the following conditions are true:

1. The VM is in state 'provisioning'
2. The VM doesn't have a server_uuid
3. The server_uuid of the VM is not present in CNAPI

In cases 2 and 3, mark the VM as destroyed and return a 200 HTTP status
code. In case 1, return an error.

Returning early and not starting a destroy workflow in these cases is
faster and doesn't take any resource in the workflow's queue, thus
allowing other workflows who have a chance to succeed to be processed
more quickly.