### PR TITLE
ZAPI-712: allow any casing for sort order

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -461,9 +461,13 @@ joyent/node-sdc-clients module.
 
 #### Sorting
 
-The *sort* direction can be 'asc' (ascending) or 'desc' (descending), and it is
-'desc' by default. The following are some examples of valid values for the *sort*
-parameter:
+The *sort* direction can be:
+
+* 'asc' or 'ASC' to sort by ascending order
+* 'desc' or 'DESC' to sort by descending order
+
+The sort direction is descending by default. The following are some examples
+of valid values for the *sort* parameter:
 
     sort=uuid (results in 'uuid DESC')
     sort=alias.desc (results in 'uuid DESC')

--- a/lib/validation/sort.js
+++ b/lib/validation/sort.js
@@ -52,6 +52,11 @@ function isValidSortCriteria(sortCriteriaString) {
     var sortKey = sortCriteriaComponents[0];
     var sortOrder = sortCriteriaComponents[1];
 
+    // Normalize sort order so that we accept any casing as valid
+    if (sortOrder !== undefined) {
+        sortOrder = sortOrder.toUpperCase();
+    }
+
     return VALID_SORT_KEYS.indexOf(sortKey) > -1 &&
         (sortOrder === undefined || VALID_SORT_ORDERS.indexOf(sortOrder) > -1);
 }

--- a/test/vms.list-sort.test.js
+++ b/test/vms.list-sort.test.js
@@ -1,0 +1,90 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2015, Joyent, Inc.
+ */
+
+var assert = require('assert-plus');
+var vasync = require('vasync');
+
+var sortValidation = require('../lib/validation/sort');
+
+var testCommon = require('./common');
+
+var CLIENT;
+
+exports.setUp = function (callback) {
+    testCommon.setUp(function (err, _client) {
+        assert.ifError(err);
+        assert.ok(_client, 'restify client');
+        CLIENT = _client;
+        callback();
+    });
+};
+
+exports.list_param_invalid_sort = function (t) {
+    var INVALID_SORT_PARAMS = [
+        'foo',
+        'foo.DESC',
+        'foo.desc',
+        'foo.ASC',
+        'foo.asc',
+        'create_timestamp.foo',
+        'create_timestamp.'
+    ];
+
+    vasync.forEachParallel({
+        func: function listWithInvalidSort(invalidSortParam, callback) {
+            var expectedError = {
+                code: 'ValidationFailed',
+                message: 'Invalid Parameters',
+                errors: [ {
+                    field: 'sort',
+                    code: 'Invalid',
+                    message: 'Invalid sort param: ' + invalidSortParam
+                } ]
+            };
+
+            testCommon.testListInvalidParams(CLIENT, {sort: invalidSortParam},
+               expectedError, t, callback);
+        },
+        inputs: INVALID_SORT_PARAMS
+    }, function allTestsDone(err) {
+        t.done();
+    });
+};
+
+exports.list_param_valid_sort = function (t) {
+    var VALID_SORT_PARAMS = [];
+    var VALID_SORT_ORDERS = ['ASC', 'asc', 'DESC', 'desc'];
+
+    sortValidation.VALID_SORT_KEYS.forEach(function (validSortKey) {
+        VALID_SORT_ORDERS.forEach(function (validSortOrder) {
+            VALID_SORT_PARAMS.push(validSortKey + '.' + validSortOrder);
+        });
+    });
+
+    vasync.forEachParallel({
+        func: function listWithValidSort(validSortParam, callback) {
+            testCommon.testListValidParams(CLIENT, {sort: validSortParam}, t,
+                function (err, body) {
+                    t.ifError(err,
+                        'Listing VMs with a valid sorting param should not ' +
+                        'result in an error');
+                    t.ok(Array.isArray(body),
+                        'The response should be an array of VMs');
+                    t.ok(body.length > 1,
+                        'The response should contain more than one VM');
+
+                    return callback();
+                });
+        },
+        inputs: VALID_SORT_PARAMS
+    }, function allTestsDone(err) {
+        t.done();
+    });
+};


### PR DESCRIPTION
These changes fix a regression that was introduced by 83ff20bed40b465ec6e9f3506a6557dc029eee64. After the changes in 83ff20bed40b465ec6e9f3506a6557dc029eee64 were merged, only lower-case order directions were accepted, whereas any case would be accepted before.

These changes also add the corresponding tests. The actual payload of sorted list responses are not tested (we just check responses status codes), but this will be done in a separate change because:

1. The actual results of sorted lists have never been tested, thus this change is not a regression in that regard
2. Testing the actual content of sorted results would require significantly more changes than what's in this PR, and would prevent us from landing it quickly to fix an important regression

/cc @trentm 