### PR TITLE
DOCKER-557: make docker rm faster

### DIFF
--- a/lib/common/util.js
+++ b/lib/common/util.js
@@ -138,13 +138,25 @@ exports.publishChange = publishChange;
 
 
 /*
- * Poll a job until it reaches either the succeeded or failed state.
+ * Poll a job until it:
+ * - reaches either the succeeded or failed state
+ * - completes a given task
+ *
+ * 'opts' is an options object whose properties can be:
+ * - 'taskName': a string that identifies the nane of the task to wait for
+ * before calling the callback 'cb'. If 'opts.taskName' is set, then pollJob
+ * will not wait for the whole job to succeed or fail, but instead will just
+ * wait for that specific task to complete.
  *
  * Note: if a job fails, it's the caller's responsibility to check for a failed
  * job.  The error object will be null even if the job fails.
  */
 
 function pollJob(opts, cb) {
+    assert.object(opts, 'opts');
+    assert.optionalString(opts.taskName,
+        'opts.taskName');
+
     var wfapi = opts.wfapi;
     var log = opts.log;
     var job_uuid = opts.job_uuid;
@@ -181,24 +193,31 @@ function pollJob(opts, cb) {
             log.debug({ job: job }, 'polling job %s (attempt %d)',
                       job_uuid, attempts);
 
-                      if (job && job.execution === 'succeeded') {
-                          return (cb(null, job));
-                      } else if (job && job.execution === 'failed') {
-                          log.warn('job %s failed', job_uuid);
-                          return (cb(null, job));
-                      } else if (job && job.execution === 'canceled') {
-                          log.warn('job %s was canceled', job_uuid);
-                          return (cb(null, job));
-                      } else if (attempts > limit) {
-                          log.warn('polling for job %s completion ' +
-                                   'timed out after %d seconds',
-                          job_uuid, limit * (timeout / 1000));
-                          return (cb(new Error(
-                              'polling for job timed out'), job));
-                      }
+            if (opts.taskName &&
+                job.execution === 'running' &&
+                job.chain_results &&
+                job.chain_results.some(function findTaskResultByName(result) {
+                    return result && result.name === opts.taskName;
+                })) {
+                return cb(null, job);
+            } else if (job && job.execution === 'succeeded') {
+              return (cb(null, job));
+            } else if (job && job.execution === 'failed') {
+              log.warn('job %s failed', job_uuid);
+              return (cb(null, job));
+            } else if (job && job.execution === 'canceled') {
+              log.warn('job %s was canceled', job_uuid);
+              return (cb(null, job));
+            } else if (attempts > limit) {
+              log.warn('polling for job %s completion ' +
+                       'timed out after %d seconds',
+              job_uuid, limit * (timeout / 1000));
+              return (cb(new Error(
+                  'polling for job timed out'), job));
+            }
 
-                      setTimeout(poll, timeout);
-                      return (null);
+            setTimeout(poll, timeout);
+            return (null);
         });
     };
 

--- a/lib/endpoints/vms.js
+++ b/lib/endpoints/vms.js
@@ -361,7 +361,7 @@ function getVm(req, res, next) {
  * whether the sync parameter is specified.
  */
 
-function handleUpdateVMResponse(req, res, next, juuid) {
+function handleUpdateVMResponse(req, res, next, juuid, taskName) {
     // Allow clients to know the location of WFAPI
     res.header('workflow-api', req.app.config.wfapi.url);
 
@@ -377,7 +377,8 @@ function handleUpdateVMResponse(req, res, next, juuid) {
         var opts = {
             log: req.log,
             job_uuid: juuid,
-            wfapi: req.app.wfapi
+            wfapi: req.app.wfapi,
+            taskName: taskName
         };
         common.waitForJob(opts, function (error) {
             if (error) {
@@ -835,8 +836,13 @@ function deleteVm(req, res, next) {
                                 return next(jobErr);
                             }
 
+                            // If sync===true, do not wait until the VM has
+                            // actually been destroyed and the whole workflow
+                            // has completed. Only wait until the VM is marked
+                            // as destroyed (the 'vmapi.mark_vm_as_destroyed'
+                            // task is finished).
                             return handleUpdateVMResponse(req, res, next,
-                                juuid);
+                                juuid, 'vmapi.mark_vm_as_destroyed');
                         });
                 }
             });

--- a/lib/workflows/destroy.js
+++ b/lib/workflows/destroy.js
@@ -19,14 +19,14 @@ var VERSION = '7.1.0';
 
 
 /*
- * Sets up a CNAPI VM action request. Take a look at common.zoneAction. Here you
- * can set parameters such as:
+ * Sets up a CNAPI VM destroy action request. Take a look at common.zoneAction.
+ * Here you can set parameters such as:
  * - request endpoint (usually the VM endpoint)
  * - jobid (so CNAPI can post status updates back to the job info object)
  * - requestMethod
  * - expects (if you want to check a specific running status of the machine)
  */
-function setupRequest(job, cb) {
+function setupDestroyRequest(job, cb) {
     job.endpoint = '/servers/' +
                    job.params['server_uuid'] + '/vms/' +
                    job.params['vm_uuid'] + '?jobid=' + job.uuid;
@@ -38,9 +38,32 @@ function setupRequest(job, cb) {
     job.action = 'destroy';
     job.server_uuid = job.params['server_uuid'];
 
-    return cb(null, 'Request has been setup!');
+    return cb(null, 'Destroy request has been setup!');
 }
 
+/*
+ * Sets up a CNAPI VM stop action request. Take a look at common.zoneAction.
+ * Here you can set parameters such as:
+ * - request endpoint (usually the VM endpoint)
+ * - jobid (so CNAPI can post status updates back to the job info object)
+ * - requestMethod
+ * - expects (if you want to check a specific running status of the machine)
+ */
+function setupStopRequest(job, cb) {
+    job.endpoint = '/servers/' +
+                   job.params['server_uuid'] + '/vms/' +
+                   job.params['vm_uuid'] + '/stop' +
+                   '?force=true&jobid=' + job.uuid;
+    job.currentVm = job.params.currentVm;
+    job.params.jobid = job.uuid;
+    job.requestMethod = 'post';
+    job.expects = 'stopped';
+    job.addedToUfds = true;
+    job.action = 'stop';
+    job.server_uuid = job.params['server_uuid'];
+
+    return cb(null, 'Stop request has been setup!');
+}
 
 /*
  * Allow the VM to be marked as destroyed preemptively on VMAPI as soon as
@@ -49,10 +72,6 @@ function setupRequest(job, cb) {
 function markVmAsDestroyed(job, cb) {
     if (!job.currentVm) {
         cb(null, 'Skipping task -- VM missing from job');
-        return;
-    }
-    if (!job.currentVm.docker) {
-        cb(null, 'Skipping task for non-Docker VMs');
         return;
     }
 
@@ -167,10 +186,10 @@ var workflow = module.exports = {
         body: common.validateForZoneAction,
         modules: {}
     }, {
-        name: 'common.setup_request',
+        name: 'common.setup_stop_request',
         timeout: 10,
         retry: 1,
-        body: setupRequest,
+        body: setupStopRequest,
         modules: {}
     }, {
         name: 'cnapi.acquire_vm_ticket',
@@ -185,19 +204,41 @@ var workflow = module.exports = {
         body: common.waitOnVMTicket,
         modules: { sdcClients: 'sdc-clients' }
     }, {
-        name: 'cnapi.destroy_vm',
+        name: 'cnapi.stop_vm',
         timeout: 10,
         retry: 1,
         body: common.zoneAction,
         modules: { restify: 'restify' }
     }, {
+        name: 'cnapi.wait_stop_vm_task',
+        timeout: 120,
+        retry: 1,
+        body: common.waitTask,
+        modules: { sdcClients: 'sdc-clients' }
+    }, {
+        name: 'common.setup_destroy_request',
+        timeout: 10,
+        retry: 1,
+        body: setupDestroyRequest,
+        modules: {}
+    }, {
+        name: 'cnapi.destroy_vm',
+        timeout: 10,
+        retry: 1,
+        body: common.zoneAction,
+        modules: { restify: 'restify' }
+    },
+    // Mark the VM as destroyed, even though the destroy task probably hasn't
+    // completed yet. This allows to return earlier and have better perceived
+    // latency for users.
+    {
         name: 'vmapi.mark_vm_as_destroyed',
         timeout: 10,
         retry: 1,
         body: markVmAsDestroyed,
         modules: { restify: 'restify' }
     }, {
-        name: 'cnapi.wait_task',
+        name: 'cnapi.wait_destroy_vm_task',
         timeout: 120,
         retry: 1,
         body: common.waitTask,


### PR DESCRIPTION
This is the result of splitting up https://github.com/joyent/sdc-vmapi/pull/16 in much smaller pieces. This PR only contains the changes needed to make `docker rm`'s perceived latency lower. It does not fix  issues like docker containers appearing in `docker ps`' output after they've been deleted by a user. I will create follow-up tickets/PRs once this approach is validated.

With this change, a request to the `DELETE /vms/<some-vm>` endpoint completes as soon as the VM has been marked as `state = 'destroyed'`. At that time, the request to stop that VM has been sent by the workflow to VMAPI, but the VM is not stopped yet. I don't think this is an issue, but it's worth pointing out because I may very well have missed some use cases for which it's not desirable (like starting a new VM that uses a resource that the deleted VM locked right after the response from the server).

I think this is the earliest stage in the workflow at which we can send the response, and it currently gives us the lowest perceived latency possible.

I'm still thinking about how to best write tests for this.