### PR TITLE
add -d command line option to add-tests-vms

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Andres Rodriguez (joyent.com)",
   "private": true,
   "dependencies": {
-    "assert-plus": "0.1.0",
+    "assert-plus": "0.2.0",
     "async": "0.2.6",
     "bunyan": "1.3.4",
     "changefeed": "1.1.3",

--- a/tools/add-test-vms.js
+++ b/tools/add-test-vms.js
@@ -15,20 +15,19 @@
  * You can specify the trace log level, the number of VMs to create and the
  * number of VMs created concurrently on the command line like following:
  *
- * $ LOG_LEVEL=trace node tools/add-test-vms.js [nb_test_vms_to_create]
- * [concurrency]
+ * Run node add-test-vms.js -h for usage.
  */
 
 var path = require('path');
 var fs = require('fs');
 
+var dashdash = require('dashdash');
 var libuuid = require('libuuid');
 var bunyan = require('bunyan');
 var restify = require('restify');
 var assert = require('assert-plus');
 
-var testCommon = require('../test/lib/vm');
-
+var testVm = require('../test/lib/vm');
 var configFileLoader = require('../lib/config-loader');
 var MORAY = require('../lib/apis/moray');
 
@@ -44,32 +43,100 @@ log = this.log = new bunyan({
     serializers: restify.bunyan.serializers
 });
 
+config.moray.reconnect = true;
 var moray = new MORAY(config.moray);
 
-moray.connect();
-moray.once('moray-ready', function () {
-    log.debug('Morary ready!');
+var cmdlineOptions = [
+    {
+        names: ['help', 'h'],
+        type: 'bool',
+        help: 'Print this help and exit'
+    },
+    {
+        names: ['n'],
+        type: 'positiveInteger',
+        help: 'Number of test VMs to create'
+    },
+    {
+        names: ['d'],
+        type: 'string',
+        help: 'JSON string representing the data used to create every test VMs.'
+    },
+    {
+        names: ['c'],
+        type: 'positiveInteger',
+        help: 'The number of VMs added concurrently'
+    }
+];
 
-    var nbTestVmsToCreate = Number(process.argv[2]) ||
-        DEFAULT_NB_TEST_VMS_TO_CREATE;
-    log.debug('Number of test VMs to create:', nbTestVmsToCreate);
-    assert.number(nbTestVmsToCreate);
+function printUsage(cmdLineOptionsParser) {
+    var help = cmdlineOptionsParser.help({includeEnv: true}).trimRight();
+    console.log('usage: node add-test-vms.js [OPTIONS]\n' +
+        'options:\n' + help);
+}
 
-    var concurrency = Number(process.argv[3]) || DEFAULT_CONCURRENCY;
-    log.debug('concurrency:', concurrency);
-    assert.number(concurrency);
+function addTestVms(nbVms, concurrency, data) {
+    assert.number(nbVms, 'nbVms must be a number');
+    assert.ok(nbVms > 0, 'nbVms must be a positive number');
 
-    testCommon.createTestVMs(nbTestVmsToCreate, moray, {
-        concurrency: concurrency,
-        log: log
-    }, {}, function allVmsCreated(err) {
-        if (err) {
-            log.error({err: err}, 'Error when creating test VMs');
-        } else {
-            log.info('All VMs created successfully');
+    assert.number(concurrency, 'concurrency must be a number');
+    assert.ok(concurrency > 0, 'concurrency must be a positive number');
+
+    assert.optionalObject(data, 'data must be an optional object');
+    data = data || {};
+
+    moray.connect();
+    moray.once('moray-ready', function () {
+        log.debug('Moray ready!');
+
+        log.debug('Number of test VMs to create:', nbTestVmsToCreate);
+        assert.number(nbTestVmsToCreate);
+
+        log.debug('concurrency:', concurrency);
+        assert.number(concurrency);
+
+        testVm.createTestVMs(nbTestVmsToCreate, moray, {
+            concurrency: concurrency,
+            log: log
+        }, data, function allVmsCreated(err) {
+            if (err) {
+                log.error({err: err}, 'Error when creating test VMs');
+            } else {
+                log.info('All VMs created successfully');
+            }
+
+            log.debug('Closing moray connection');
+            moray.connection.close();
+        });
+    });
+}
+
+var cmdlineOptionsParser = dashdash.createParser({options: cmdlineOptions});
+var nbTestVmsToCreate;
+var concurrency;
+var testVmsData;
+var parsedCmdlineOpts;
+
+try {
+    parsedCmdlineOpts = cmdlineOptionsParser.parse(process.argv);
+
+    if (parsedCmdlineOpts.help) {
+        printUsage(cmdlineOptionsParser);
+    } else {
+        nbTestVmsToCreate = Number(parsedCmdlineOpts.n) ||
+            DEFAULT_NB_TEST_VMS_TO_CREATE;
+
+        concurrency = Number(parsedCmdlineOpts.c) ||
+            DEFAULT_CONCURRENCY;
+
+        if (parsedCmdlineOpts.d) {
+            testVmsData = JSON.parse(parsedCmdlineOpts.d);
         }
 
-        log.debug('Closing moray connection');
-        moray.connection.close();
-    });
-});
+        addTestVms(nbTestVmsToCreate, concurrency, testVmsData);
+    }
+} catch (err) {
+    console.error('Could not parse command line options');
+    printUsage(cmdlineOptionsParser);
+    process.exit(1);
+}


### PR DESCRIPTION
This can be used to set custom data on tests VMs.  Also refactor command
line parsing to use dashdash. Bump assert-plus dependency to avoid
assert in dashdash options checking.

/cc @joshwilsdon