### PR TITLE
ZAPI-733: killVm endpoint should only accept strings for its "signal" query string parameter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1112,7 +1112,7 @@ operations is documented below.
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- |
 | uuid       | UUID    | VM UUID                                                                                                                                                                                          | Yes       |
 | owner_uuid | UUID    | VM Owner. If specified, the VM object will be checked for ownership against this owner_uuid. If vm.owner_uuid does not match the provided value the call will result in a 404 VM Not Found error | No        |
-| action     | String  | start, stop, reboot, reprovision, update, add_nics, remove_nics, create_snapshot, delete_snapshot, rollback_snapshot                                                                             | Yes       |
+| action     | String  | start, stop, kill, reboot, reprovision, update, add_nics, remove_nics, create_snapshot, delete_snapshot, rollback_snapshot                                                                             | Yes       |
 | sync       | Boolean | Wait for workflow to complete before returning                                                                                                                                                   | No        |
 
 ### Response Codes
@@ -1133,6 +1133,7 @@ Also allows:
 | Param      | Type   | Description                                                                                            |
 | ---------- | ------ | ------------------------------------------------------------------------------------------------------ |
 | update     | Object | Optional data to update the vm with before it's started. Currently limited to 'set_internal_metadata'. |
+| idempotent | Boolean| Optional flag to specify whether the request should be considered idempotent. If the request should be considered idempotent, a failure to start a VM because it's already been started will not result in an error. |
 
 ### Example
 
@@ -1140,11 +1141,32 @@ Also allows:
 
 ## StopVm (POST /vms/:uuid?action=stop)
 
-No additional inputs are needed for this action.
+See [General Inputs](#general-inputs)
+
+Also allows:
+
+| Param      | Type   | Description                                                                                            |
+| ---------- | ------ | ------------------------------------------------------------------------------------------------------ |
+| idempotent | Boolean| Optional flag to specify whether the request should be considered idempotent. If the request should be considered idempotent, a failure to stop a VM because it's already been stopped will not result in an error. |
 
 ### Example
 
     POST /vms/e9bd0ed1-7de3-4c66-a649-d675dbce6e83?action=stop
+
+## KillVm (POST /vms/:uuid?action=kill)
+
+See [General Inputs](#general-inputs)
+
+Also allows:
+
+| Param      | Type   | Description                                                                                            |
+| ---------- | ------ | ------------------------------------------------------------------------------------------------------ |
+| signal     | String | Optional data to specify which signal to use when killing the process that runs as the init process in the corresponding VM. |
+| idempotent | Boolean| Optional flag to specify whether the request should be considered idempotent. If the request should be considered idempotent, a failure to kill a VM because it's already been killed will not result in an error. |
+
+### Example
+
+    POST /vms/e9bd0ed1-7de3-4c66-a649-d675dbce6e83?action=start
 
 ## RebootVm (POST /vms/:uuid?action=reboot)
 
@@ -1155,6 +1177,7 @@ Also allows:
 | Param      | Type   | Description                                                                                            |
 | ---------- | ------ | ------------------------------------------------------------------------------------------------------ |
 | update     | Object | Optional data to update the vm with before it's started. Currently limited to 'set_internal_metadata'. |
+| idempotent | Boolean| Optional flag to specify whether the request should be considered idempotent. If the request should be considered idempotent, a failure to reboot a VM because it's already been rebooted will not result in an error. |
 
 ### Example
 

--- a/lib/endpoints/vms.js
+++ b/lib/endpoints/vms.js
@@ -556,8 +556,9 @@ function killVm(req, res, next) {
         'HUP', 'ILL', 'INT', 'IO', 'IOT', 'KILL', 'LOST', 'PIPE', 'POLL',
         'PROF', 'PWR', 'QUIT', 'SEGV', 'STOP', 'SYS', 'TERM', 'TRAP', 'TSTP',
         'TTIN', 'TTOU', 'URG', 'USR1', 'USR2', 'VTALRM', 'WINCH', 'XCPU',
-        'XFSZ', 0, 1, 2, 3, 4, 5, 6, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-        18, 19, 20, 21, 22, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 37
+        'XFSZ', '0', '1', '2', '3', '4', '5', '6', '6', '8', '9', '10', '11',
+        '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '22',
+        '23', '24', '25', '26', '27', '28', '29', '30', '31', '37'
     ];
 
     req.log.trace({ vm_uuid: req.params.uuid }, 'KillVm start');

--- a/lib/workflows/provision.js
+++ b/lib/workflows/provision.js
@@ -275,7 +275,7 @@ function preparePayload(job, cb) {
         'max_swap', 'mdata_exec_timeout', 'nics',
         'owner_uuid', 'quota', 'ram',
         'resolvers', 'vcpus', 'zfs_data_compression', 'zfs_io_priority',
-        'zlog_max_size', 'tags', 'tmpfs'
+        'zlog_max_size', 'tags', 'tmpfs', 'restart_init'
     ];
 
     for (i = 0; i < keys.length; i++) {

--- a/test/lib/workflow.js
+++ b/test/lib/workflow.js
@@ -1,0 +1,79 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2016, Joyent, Inc.
+ */
+
+// In seconds
+var TIMEOUT = 120;
+
+function checkJob(t, job) {
+    t.ok(job.uuid, 'uuid');
+    t.ok(job.name, 'name');
+    t.ok(job.execution, 'execution');
+    t.ok(job.params, 'params');
+}
+
+
+function checkEqual(value, expected) {
+    if ((typeof (value) === 'object') && (typeof (expected) === 'object')) {
+        var exkeys = Object.keys(expected);
+        for (var i = 0; i < exkeys.length; i++) {
+            var key = exkeys[i];
+            if (value[key] !== expected[key])
+                return false;
+        }
+
+        return true;
+    } else {
+        return (value === expected);
+    }
+}
+
+
+function checkValue(client, url, key, value, callback) {
+    return client.get(url, function (err, req, res, body) {
+        if (err) {
+            return callback(err);
+        }
+
+        return callback(null, checkEqual(body[key], value));
+    });
+}
+
+function waitForValue(client, url, key, value, callback) {
+    var times = 0;
+
+    function onReady(err, ready) {
+        if (err) {
+            callback(err);
+            return;
+        }
+
+        if (!ready) {
+            times++;
+
+            if (times == TIMEOUT) {
+                throw new Error('Timeout waiting on ' + url);
+            } else {
+                setTimeout(function () {
+                    waitForValue(client, url, key, value, callback);
+                }, 1000);
+            }
+        } else {
+            times = 0;
+            callback(null);
+        }
+    }
+
+    return checkValue(client, url, key, value, onReady);
+}
+
+module.exports = {
+    checkJob: checkJob,
+    waitForValue: waitForValue
+};

--- a/test/vms.delete_non_existing_no_workflow.test.js
+++ b/test/vms.delete_non_existing_no_workflow.test.js
@@ -36,7 +36,7 @@ exports.setUp = function (callback) {
 exports.create_vm_with_null_server_uuid = function (t) {
     client.put('/vms/' + TEST_VM_UUID, {
         uuid: TEST_VM_UUID,
-        alias: vmTest.TEST_VMS_ALIAS,
+        alias: vmTest.getUniqueTestVMName('null-server-uuid'),
         state: 'running'
     }, function onPutDone(err, req, res, newVm) {
         t.ifError(err, 'The test VM should be created succesfully');
@@ -63,7 +63,7 @@ exports.create_vm_on_non_existing_server_uuid = function (t) {
     client.put('/vms/' + TEST_VM_UUID, {
         uuid: TEST_VM_UUID,
         server_uuid: NON_EXISTING_CN_UUID,
-        alias: vmTest.TEST_VMS_ALIAS,
+        alias: vmTest.getUniqueTestVMName('non-existing-server-uuid'),
         state: 'running'
     }, function onPutDone(err, req, res, newVm) {
         t.ifError(err, 'The test VM should be created succesfully');
@@ -90,7 +90,7 @@ exports.delete_vm_on_non_existing_server_uuid = function (t) {
 exports.create_provisioning_vm = function (t) {
     client.put('/vms/' + TEST_VM_UUID, {
         uuid: TEST_VM_UUID,
-        alias: vmTest.TEST_VMS_ALIAS,
+        alias: vmTest.getUniqueTestVMName('provisioning-vm'),
         state: 'provisioning'
     }, function onPutDone(err, req, res, newVm) {
         t.ifError(err, 'The test VM should be created succesfully');

--- a/test/vms.kill.test.js
+++ b/test/vms.kill.test.js
@@ -1,0 +1,304 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2016, Joyent, Inc.
+ */
+
+var assert = require('assert-plus');
+var libuuid = require('libuuid');
+
+var client;
+var jobLocation;
+var vmLocation;
+
+var common = require('./common');
+var testVm = require('./lib/vm');
+var workflow = require('./lib/workflow');
+
+var TEST_SMARTOS_IMAGE_UUID = 'fd2cc906-8938-11e3-beab-4359c665ac99';
+var TEST_CUSTOMER_UUID = common.config.ufdsAdminUuid;
+var NETWORKS = null;
+var SERVER = null;
+var DOCKER_BUSYBOX_IMAGE;
+
+exports.setUp = function (callback) {
+    common.setUp(function (err, _client) {
+        assert.ifError(err);
+        assert.ok(_client, 'restify client');
+        client = _client;
+        callback();
+    });
+};
+
+exports.find_headnode = function (t) {
+    client.cnapi.get('/servers', function (err, req, res, servers) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.ok(servers);
+        t.ok(Array.isArray(servers));
+        for (var i = 0; i < servers.length; i++) {
+            if (servers[i].headnode === true) {
+                SERVER = servers[i];
+                break;
+            }
+        }
+        t.ok(SERVER);
+        t.done();
+    });
+};
+
+exports.napi_networks_ok = function (t) {
+    client.napi.get('/networks', function (err, req, res, networks) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        t.ok(networks);
+        t.ok(Array.isArray(networks));
+        t.ok(networks.length > 1);
+        NETWORKS = networks;
+        t.done();
+    });
+};
+
+exports.create_vm = function (t) {
+    var vm = {
+        alias: testVm.getUniqueTestVMName('kill-test'),
+        owner_uuid: TEST_CUSTOMER_UUID,
+        image_uuid: TEST_SMARTOS_IMAGE_UUID,
+        server_uuid: SERVER.uuid,
+        networks: [ { uuid: NETWORKS[0].uuid } ],
+        brand: 'joyent-minimal',
+        billing_id: '00000000-0000-0000-0000-000000000000',
+        ram: 64,
+        quota: 10,
+        creator_uuid: TEST_CUSTOMER_UUID,
+        // Set restart_init to false so that init doesn't restart when the VM
+        // is killed with SIGKILL and we can check that the signal was
+        // properly sent and handled by checking that the VM is stopped.
+        restart_init: false
+    };
+
+    var opts = {
+        path: '/vms'
+    };
+
+    client.post(opts, vm, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        common.checkHeaders(t, res.headers);
+        t.ok(res.headers['workflow-api'], 'workflow-api header');
+        t.ok(body, 'vm ok');
+
+        jobLocation = '/jobs/' + body.job_uuid;
+        vmLocation = '/vms/' + body.vm_uuid;
+
+        client.get(vmLocation, function (err2, req2, res2, body2) {
+            t.ifError(err2);
+            t.equal(res2.statusCode, 200, '200 OK');
+            common.checkHeaders(t, res2.headers);
+            t.ok(body2, 'provisioning vm ok');
+
+            client.post(vmLocation, { action: 'stop' },
+              function (err3, req3, res3, body3) {
+                t.equal(res3.statusCode, 409, 'cannot stop unprovisioned VM');
+                common.checkHeaders(t, res3.headers);
+                t.done();
+            });
+        });
+    });
+};
+
+exports.get_job = function (t) {
+    client.get(jobLocation, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200, 'GetJob 200 OK');
+        common.checkHeaders(t, res.headers);
+        t.ok(body, 'job ok');
+        workflow.checkJob(t, body);
+        t.done();
+    });
+};
+
+
+exports.wait_provisioned_job = function (t) {
+    workflow.waitForValue(client, jobLocation, 'execution', 'succeeded',
+        function (err) {
+            t.ifError(err);
+            t.done();
+        });
+};
+
+exports.kill_vm_with_default_signal_ok = function (t) {
+    var params = {
+        action: 'kill',
+        sync: 'true'
+    };
+
+    var opts = {
+        path: vmLocation
+    };
+
+    client.post(opts, params, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        t.done();
+    });
+};
+
+
+// The previous request didn't specify a signal, and thus the default signal
+// was sent by vmadm to the VM, which is SIGTERM. SIGTERM doesn't terminate
+// the init process of a container, and thus the VM should still be running.
+exports.check_vm_is_still_running = function (t) {
+    client.get({path: vmLocation}, function (err, req, res, body) {
+        t.equal(body.state, 'running');
+        t.done();
+    });
+};
+
+exports.kill_vm_with_symbolic_kill_signal_ok = function (t) {
+    var params = {
+        action: 'kill',
+        signal: 'SIGKILL',
+        sync: 'true'
+    };
+
+    var opts = {
+        path: vmLocation
+    };
+
+    client.post(opts, params, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        t.done();
+    });
+};
+
+// The previous request specified a SIGKILL signal, which terminates the init
+// process of a SmartOS container, and thus the VM should be stopped.
+exports.check_vm_is_stopped_after_symbolic_sigkill = function (t) {
+    client.get({path: vmLocation}, function (err, req, res, body) {
+        t.equal(body.state, 'stopped');
+        t.done();
+    });
+};
+
+exports.restart_stopped_vm_after_symbolic_sigkill = function (t) {
+    var params = {
+        action: 'start',
+        sync: 'true'
+    };
+
+    var opts = {
+        path: vmLocation
+    };
+
+    client.post(opts, params, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        t.done();
+    });
+};
+
+exports.check_vm_is_running_after_restart_from_symbolic_sigkill =
+    function (t) {
+        client.get({path: vmLocation}, function (err, req, res, body) {
+            t.equal(body.state, 'running');
+            t.done();
+        });
+    };
+
+exports.kill_vm_with_numeric_signal_as_string_ok = function (t) {
+    var params = {
+        action: 'kill',
+        signal: '9',
+        sync: 'true'
+    };
+
+    var opts = {
+        path: vmLocation
+    };
+
+    client.post(opts, params, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        t.done();
+    });
+};
+
+// The previous request specified a SIGKILL signal with its numeric
+// representaiton ('9'), which terminates the init process of a SmartOS
+// container, and thus the VM should be stopped.
+exports.check_vm_is_stopped_after_numeric_sigkill = function (t) {
+    client.get({path: vmLocation}, function (err, req, res, body) {
+        t.equal(body.state, 'stopped');
+        t.done();
+    });
+};
+
+exports.restart_stopped_vm_after_numeric_sigkill = function (t) {
+    var params = {
+        action: 'start',
+        sync: 'true'
+    };
+
+    var opts = {
+        path: vmLocation
+    };
+
+    client.post(opts, params, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        t.done();
+    });
+};
+
+exports.check_vm_is_running_after_restart_from_numeric_sigkill = function (t) {
+    client.get({path: vmLocation}, function (err, req, res, body) {
+        t.equal(body.state, 'running');
+        t.done();
+    });
+};
+
+// The "signal" parameter of the KillVm endpoint has to be a string, not a
+// number, so this test results in an invalid parameter error.
+exports.kill_vm_with_numeric_signal_as_number_ko = function (t) {
+    var params = {
+        action: 'kill',
+        signal: 9
+    };
+
+    var opts = {
+        path: vmLocation + '?action=update'
+    };
+
+    client.post(opts, params, function (err, req, res, body) {
+        t.ok(err);
+        t.equal(res.statusCode, 409);
+        t.done();
+    });
+};
+
+exports.check_vm_is_still_running_after_failed_kill = function (t) {
+    client.get({path: vmLocation}, function (err, req, res, body) {
+        t.equal(body.state, 'running');
+        t.done();
+    });
+};
+
+exports.delete_vm = function (t) {
+    var opts = {
+        path: vmLocation + '?sync=true'
+    };
+
+    client.del(opts, function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 202);
+        common.checkHeaders(t, res.headers);
+        t.ok(body);
+        t.done();
+    });
+};

--- a/test/vms.marker.test.js
+++ b/test/vms.marker.test.js
@@ -87,11 +87,7 @@ function testMarkerPagination(options, t, callback) {
         limit: LIMIT
     };
 
-    if (vmsCreationParams.alias !== undefined)
-        queryStringObject.alias = vmTest.TEST_VMS_ALIAS +
-            vmsCreationParams.alias;
-    else
-        queryStringObject.alias = vmTest.TEST_VMS_ALIAS;
+    queryStringObject.alias = vmTest.getTestVMsPrefix(vmsCreationParams.alias);
 
     if (options.sort !== undefined)
         queryStringObject.sort = options.sort;
@@ -113,7 +109,10 @@ function testMarkerPagination(options, t, callback) {
             },
             function createFakeVms(next) {
                 vmTest.createTestVMs(NB_TEST_VMS_TO_CREATE, moray,
-                    {concurrency: 100}, vmsCreationParams,
+                    {
+                        concurrency: 100,
+                        uniqueAlias: options.uniqueAlias
+                    }, vmsCreationParams,
                     function fakeVmsCreated(err, vmsUuid) {
                         moray.connection.close();
 
@@ -426,7 +425,7 @@ var NON_STRICT_TOTAL_ORDER_SORT_KEYS = {
     tags: vmCommon.objectToTagFormat({sometag: 'foo'}),
     brand: 'foobrand',
     state: 'test',
-    alias: 'test--marker-pagination',
+    alias: 'test-marker-pagination',
     max_physical_memory: 42,
     create_timestamp: Date.now(),
     docker: true
@@ -466,7 +465,8 @@ function createValidMarkerTest(sortKey, sortOrder, exports) {
         testMarkerPagination({
             sort: sortKey + '.' + sortOrder,
             markerKeys: [sortKey, 'uuid'],
-            vmsCreationParams: vmsCreationParams
+            vmsCreationParams: vmsCreationParams,
+            uniqueAlias: sortKey === 'alias' ? false: true
         }, t, function testDone() {
             t.done();
         });


### PR DESCRIPTION
`node-vmadm`'s `kill` API only accepts signals as strings, so accepting numbers as input for the `KillVm` endpoint of VMAPI and passing them to `node-vmadm` as numbers doesn't make sense.

Instead, these strings should be used to represent any signal whether in their symbolic form, such as `SIGKILL`, or their numeric form (e.g `9`) across all APIs and modules.

This PR implements this change in VMAPI. It also brings the following notable changes:
1. It documents the `KillVm` endpoint. Is that appropriate, or is the `KillVm` endpoint considered internal/private?
2. It adds tests for the `KillVm` endpoint. More thorough tests will need to be added in a follow-up commit so that we can test that all supported signals behave as expected. But for now I believe this is a significant improvement on the existing tests for the `KillVm` endpoint.
3. It allows requests to pass a `restart_init` to the provisioning workflow. This is used so that tests for the `KillVm` endpoint can send various signals and test whether they've been handled by checking whether a VM is stopped or still running. Without being able to pass `restart_init: false`, init would restart every time a `SIGKILL` signal would be sent to a VM, and thus tests would not be able to determine whether that signal was handled without making them much more complex.
4. It makes a few tests use unique names for the VMs that they create, so that tests don't use duplicate aliases. It's a work in progress though, more tests will need to be changed to use unique names later.
5. It factors out some workflow utils used by some tests suites in `test/lib/workflow.js`.

I believe these changes are not breaking any consumer of this API since:
- sdc-docker never passes any other signal than SIGKILL, because it doesn't parse the query string for a `signal` parameter.
- cloudapi doesn't implement a `KillVm` endpoint.

But I may be missing something.
