### PR TITLE
joyent/sdc-vmapi#40 vmapi crashes when sdc-migrate -n given name instead of UUID

### DIFF
--- a/lib/vm-migration/migrate.js
+++ b/lib/vm-migration/migrate.js
@@ -414,6 +414,28 @@ function migrateVm(req, res, next) {
             }
 
             if (action === 'begin' || action === 'estimate') {
+                // Validate override params.
+                if (req.params.override_server_uuid &&
+                        !common.validUUID(req.params.override_server_uuid)) {
+                    cb(new errors.ValidationFailedError(
+                        'Invalid parameters: override_server_uuid (' +
+                        req.params.override_server_uuid +
+                        ') is not a valid UUID',
+                        [ errors.invalidUuidErrorsElem('override_server_uuid') ]
+                        ));
+                    return;
+                }
+
+                if (req.params.override_uuid &&
+                        !common.validUUID(req.params.override_uuid)) {
+                    cb(new errors.ValidationFailedError(
+                        'Invalid parameters: override_uuid (' +
+                        req.params.override_uuid + ') is not a valid UUID',
+                        [ errors.invalidUuidErrorsElem('override_uuid') ]
+                        ));
+                    return;
+                }
+
                 ctx.app = req.app;
                 validateMigrationBegin(vm, ctx, cb);
                 return;

--- a/lib/vm-migration/migrate.js
+++ b/lib/vm-migration/migrate.js
@@ -50,10 +50,26 @@ function validateMigrationBegin(vm, ctx, callback) {
     assert.optionalBool(ctx.app.options.userMigrationAllowed,
         'ctx.app.options.userMigrationAllowed');
     assert.optionalObject(ctx.migrationRecord, 'ctx.migrationRecord');
+    assert.object(ctx.req, 'ctx.req');
     assert.func(callback, 'callback');
     assert.optionalUuid(ctx.ownerUuid, 'ctx.ownerUuid');
 
+    var checkUuidProps = ['override_server_uuid', 'override_uuid'];
+    var i;
+    var p;
     var vmAllowed = false;
+
+    // Validate override params.
+    for (i = 0; i < checkUuidProps.length; i++) {
+        p = checkUuidProps[i];
+        if (ctx.req.params[p] && !common.validUUID(ctx.req.params[p])) {
+            callback(new errors.ValidationFailedError(util.format(
+                'Invalid parameters: %s (%s) is not a valid UUID',
+                p, ctx.req.params[p]), [ errors.invalidUuidErrorsElem(p) ]
+            ));
+            return;
+        }
+    }
 
     if (!ctx.ownerUuid) {
         // This is an operator initiated migration - always allow it.
@@ -414,29 +430,8 @@ function migrateVm(req, res, next) {
             }
 
             if (action === 'begin' || action === 'estimate') {
-                // Validate override params.
-                if (req.params.override_server_uuid &&
-                        !common.validUUID(req.params.override_server_uuid)) {
-                    cb(new errors.ValidationFailedError(
-                        'Invalid parameters: override_server_uuid (' +
-                        req.params.override_server_uuid +
-                        ') is not a valid UUID',
-                        [ errors.invalidUuidErrorsElem('override_server_uuid') ]
-                        ));
-                    return;
-                }
-
-                if (req.params.override_uuid &&
-                        !common.validUUID(req.params.override_uuid)) {
-                    cb(new errors.ValidationFailedError(
-                        'Invalid parameters: override_uuid (' +
-                        req.params.override_uuid + ') is not a valid UUID',
-                        [ errors.invalidUuidErrorsElem('override_uuid') ]
-                        ));
-                    return;
-                }
-
                 ctx.app = req.app;
+                ctx.req = req;
                 validateMigrationBegin(vm, ctx, cb);
                 return;
             }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmapi",
   "description": "VMs API",
-  "version": "9.8.16",
+  "version": "9.8.17",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {

--- a/test/lib/migration.js
+++ b/test/lib/migration.js
@@ -46,7 +46,7 @@ function expectErrorProperties(t, err, expectedErr) {
             return;
         }
 
-        if (err[prop] != expectedErr[prop]) {
+        if (err[prop] !== expectedErr[prop]) {
             t.ok(false, 'Error property "' + prop + '" is not as expected. ' +
                 'Expected "' + expectedErr[prop] + '" but got "' +
                 err[prop] + '"');


### PR DESCRIPTION
Fixes #40 