### PR TITLE
TRITON-1962 snapshot create not working for docker-compose containers

### DIFF
--- a/lib/endpoints/vms.js
+++ b/lib/endpoints/vms.js
@@ -2406,6 +2406,7 @@ function createVm(req, res, next) {
  * for this VM.
  */
 function canSnapshot(vm) {
+    var volumesFrom;
 
     if (['joyent', 'joyent-minimal', 'lx', 'bhyve'].indexOf(vm.brand) === -1) {
         return (new errors.BrandNotSupportedError(
@@ -2426,8 +2427,20 @@ function canSnapshot(vm) {
     if (vm.docker &&
         vm.internal_metadata.hasOwnProperty('docker:volumesfrom')) {
 
-        return (new errors.BrandNotSupportedError('snapshots are not '
-            + 'supported for docker VMs that use --volumes-from'));
+        // Note the docker volumes inside of internal_metadata is JSON encoded.
+        try {
+            volumesFrom = JSON.parse(
+                vm.internal_metadata['docker:volumesfrom']);
+        } catch (ex) {
+            return (new errors.BrandNotSupportedError(
+                'snapshots are not supported for VMs with invalid docker ' +
+                '--volumes-from'));
+        }
+
+        if (!Array.isArray(volumesFrom) || volumesFrom.length > 0) {
+            return (new errors.BrandNotSupportedError('snapshots are not '
+                + 'supported for docker VMs that use --volumes-from'));
+        }
     }
 
     /*

--- a/test/vms.migrate.test.js
+++ b/test/vms.migrate.test.js
@@ -85,7 +85,7 @@ var configurations = [
                 'docker:cmd': '["sh","-c","sleep 86400"]',
                 'docker:env': '["PATH=/usr/local/sbin:/usr/local/bin:' +
                     '/usr/sbin:/usr/bin:/sbin:/bin"]',
-                'docker:volumesfrom': '"[]"'
+                'docker:volumesfrom': '[]'
             },
             owner_uuid: ADMIN_USER_UUID,
             tags: {

--- a/test/vms.migrate.test.js
+++ b/test/vms.migrate.test.js
@@ -84,7 +84,8 @@ var configurations = [
             internal_metadata: {
                 'docker:cmd': '["sh","-c","sleep 86400"]',
                 'docker:env': '["PATH=/usr/local/sbin:/usr/local/bin:' +
-                    '/usr/sbin:/usr/bin:/sbin:/bin"]'
+                    '/usr/sbin:/usr/bin:/sbin:/bin"]',
+                'docker:volumesfrom': '"[]"'
             },
             owner_uuid: ADMIN_USER_UUID,
             tags: {


### PR DESCRIPTION
So docker-compose passes an empty volumesfrom entry, which gets serialized into the internal_metadata as an empty array string.

Added test case to docker to replicate this state.