### PR TITLE
TRITON-2126 sdc-migrate fails when an instance uses two nics on the same network

### DIFF
--- a/lib/endpoints/vms.js
+++ b/lib/endpoints/vms.js
@@ -1643,6 +1643,8 @@ function provisionNetNics(req, cb) {
             return;
         }
 
+        var networksChecked = {};
+
         function createNic(network, done) {
             // If there is at least one provisioned NIC in one of the
             // networks provided, skip napi.provisionNic for this network
@@ -1652,7 +1654,16 @@ function provisionNetNics(req, cb) {
             });
 
             if (netNics.length > 0) {
-                nics.push.apply(nics, netNics);
+                // Catch when provisioning multiple nics that reside on the same
+                // network. This function is called once per network - so we
+                // don't want to add the same NICs multiple times - TRITON-2126.
+                if (!networksChecked.hasOwnProperty(network.ipv4_uuid)) {
+                    nics.push.apply(nics, netNics);
+                    networksChecked[network.ipv4_uuid] = true;
+                    req.log.info({netNics: netNics},
+                        'NICs are already provisioned for the network');
+                }
+
                 done();
                 return;
             }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmapi",
   "description": "VMs API",
-  "version": "9.9.2",
+  "version": "9.9.3",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {

--- a/test/lib/migration.js
+++ b/test/lib/migration.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var stream = require('stream');
@@ -479,92 +479,6 @@ function TestMigrationCfg(test, cfg) {
             });
         };
     });
-
-    test.bad_migrate_core_zone = function (t) {
-        // Should not be able to migrate a triton core zone.
-        vasync.pipeline({arg: {}, funcs: [
-            function findCoreZone(ctx, next) {
-                client.get({
-                    path: '/vms?tag.smartdc_type=core&state=active&limit=1'
-                }, function onFindCoreZone(err, req, res, body) {
-                    if (err) {
-                        t.ok(false, 'unable to query vmapi for core zone: ' +
-                            err);
-                        next(true);
-                        return;
-                    }
-                    if (!body || !body[0] || !body[0].uuid) {
-                        t.ok(false, 'no core zone found');
-                        next(true);
-                        return;
-                    }
-                    ctx.vm = body[0];
-                    next();
-                });
-            },
-
-            function migrateCoreZone(ctx, next) {
-                client.post({
-                    path: format(
-                        '/vms/%s?action=migrate&migration_action=begin',
-                        ctx.vm.uuid)
-                }, function onMigrateCoreZoneCb(err) {
-                    t.ok(err, 'expect an error for migration of a core zone');
-                    if (err) {
-                        t.equal(err.statusCode, 412,
-                            format('err.statusCode === 412, got %s',
-                                err.statusCode));
-                    }
-                    next();
-                });
-            }
-        ]}, function _pipelineCb() {
-            t.done();
-        });
-    };
-
-    test.bad_migrate_nat_zone = function (t) {
-        // Should not be able to migrate a triton NAT zone.
-        vasync.pipeline({arg: {}, funcs: [
-            function findNatZone(ctx, next) {
-                client.get({
-                    path: '/vms?tag.smartdc_role=nat&state=active&limit=1'
-                }, function onFindNatZone(err, req, res, body) {
-                    if (err) {
-                        t.ok(false, 'unable to query vmapi for nat zone: ' +
-                            err);
-                        next(true);
-                        return;
-                    }
-                    if (!body || !body[0] || !body[0].uuid) {
-                        t.ok(true, 'SKIP - no nat zone found');
-                        next(true);
-                        return;
-                    }
-                    ctx.vm = body[0];
-                    next();
-                });
-            },
-
-            function migrateNatZone(ctx, next) {
-                client.post({
-                    path: format(
-                        '/vms/%s?action=migrate&migration_action=begin',
-                        ctx.vm.uuid)
-                }, function onMigrateNatZoneCb(err) {
-                    t.ok(err, 'expect an error for migration of a nat zone');
-                    if (err) {
-                        t.equal(err.statusCode, 412,
-                            format('err.statusCode === 412, got %s',
-                                err.statusCode));
-                    }
-                    next();
-                });
-            }
-        ]}, function _pipelineCb() {
-            t.done();
-        });
-    };
 
     test.migration_estimate = function test_migration_estimate(t) {
         if (!sourceVm) {


### PR DESCRIPTION
Tested through the addition of a second fabric NIC on all migrated instances.