### PR TITLE
Revert "TRITON-2130 Add snapshot-limit to VMAPI (#65)" (needs more work)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,6 @@ update time.
 | tmpfs                    | Number                        | Amount of memory for the /tmp filesystem                                                                                                                                                                                  | No                  | Yes    | Yes    |
 | zfs_data_compression     | String                        | Specifies a compression algorithm used for the VM's data dataset                                                                                                                                                          | No                  | Yes    | Yes    |
 | zfs_io_priority          | Number                        | ZFS IO Priority                                                                                                                                                                                                           | Yes                 | Yes    | Yes    |
-| zfs_snapshot_limit       | Number                        | Sets the number of ZFS snapshots a VM can take.                                                                                            | Yes                 | Yes    | Yes    |
 | zlog_max_size            | Number                        | Sets the maximum size of the stdio.log file for a docker zone before rotation. NOTE: To be used by sdc-docker only.                                                                                                       | No                  | Yes    | Yes    |
 
 Furthermore, when dealing with KVM VMs there are additional attributes to know
@@ -1113,14 +1112,13 @@ VMs can optionally be provisioned by only providing a 'billing_id' SDC Package i
 | max_swap            | Number (MiB) |
 | quota               | Number (GiB) |
 | zfs_io_priority     | Number       |
-| zfs_snapshot_limit  | Number       |
 | vcpus               | Number       |
 
 However, these values can still be individualy overriden by providing new values for them in the VM provisionm payload. Note that for the purpose of having a 1:1 VM - SDC Package correspondence it is advised that individual values should not be overriden when it is needed to refer a VM back to its original SDC Package.
 
 ### General Optional Inputs
 
-These inputs can be passed and will be validated whether or not a 'billing_id' SDC Package parameter has been provided.
+These inputs can be passed and will be validated wether or not a 'billing_id' SDC Package parameter has been provided.
 
 | Param               | Type         | Description                                 |
 | ------------------- | ------------ | ------------------------------------------- |
@@ -1130,7 +1128,6 @@ These inputs can be passed and will be validated whether or not a 'billing_id' S
 | max_physical_memory | Number (MiB) | Same as RAM                                 |
 | max_swap            | Number (MiB) | Defaults to 2 x RAM if not specified        |
 | zfs_io_priority     | Number       | ZFS IO Priority                             |
-| zfs_snapshot_limit  | Number       | Number of ZFS snapshots a VM can take       |
 | cpu_cap             | Number       | CPU Cap                                     |
 | max_lwps            | Number       | Max. Lightweight Processes                  |
 | quota               | Number (GiB) | VM quota                                    |
@@ -1333,7 +1330,6 @@ The UpdateVm payload would automatically retrieve the following values from the 
 | max_swap            | Number (MiB) |
 | quota               | Number (GiB) |
 | zfs_io_priority     | Number       |
-| zfs_snapshot_limit  | Number       |
 | vcpus               | Number       |
 
 ### Updating a VM With Individual VM Values
@@ -1349,7 +1345,6 @@ In addition to 'billing_id', the following values can be specified to update add
 | max_physical_memory (MiB) | Number                        | Same as RAM                                                                              |
 | max_swap (MiB)            | Number                        | Defaults to 2 x RAM if not specified                                                     |
 | zfs_io_priority           | Number                        | ZFS IO Priority                                                                          |
-| zfs_snapshot_limit        | Number                        | Number of ZFS snapshots a VM can take                                                 |
 | cpu_cap                   | Number                        | CPU Cap                                                                                  |
 | max_lwps                  | Number                        | Max. Lightweight Processes                                                               |
 | quota (GiB)               | Number                        | VM quota (disk)                                                                          |

--- a/lib/common/validation.js
+++ b/lib/common/validation.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2020 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -274,10 +274,6 @@ var VM_FIELDS = [
         mutable: true
     },
     {
-        name: 'zfs_snapshot_limit',
-        mutable: true
-    },
-    {
         name: 'zlog_max_size',
         mutable: true
     },
@@ -459,8 +455,6 @@ var validators = {
     zfs_data_compression: createValidateStringFn('zfs_data_compression'),
 
     zfs_io_priority: createValidateNumberFn('zfs_io_priority'),
-
-    zfs_snapshot_limit: createValidateNumberFn('zfs_snapshot_limit'),
 
     zlog_max_size: createValidateNumberFn('zlog_max_size')
 

--- a/lib/common/vm-common.js
+++ b/lib/common/vm-common.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2020 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 var assert = require('assert-plus');
@@ -143,7 +143,6 @@ function translateVm(obj, fullObject) {
         tags: obj.tags,
         zfs_filesystem: obj.zfs_filesystem,
         zfs_io_priority: obj.zfs_io_priority,
-        zfs_snapshot_limit: obj.zfs_snapshot_limit,
         zone_state: obj.zone_state,
         zonepath: obj.zonepath,
         zpool: obj.zpool
@@ -173,8 +172,7 @@ function translateVm(obj, fullObject) {
         'package_version',
         'pid',
         'tmpfs',
-        'zfs_data_compression',
-        'zfs_snapshot_limit'
+        'zfs_data_compression'
     ];
 
     optionalFields.forEach(function (field) {

--- a/lib/workflows/provision.js
+++ b/lib/workflows/provision.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2020 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -165,7 +165,7 @@ function preparePayload(job, cb) {
         'max_swap', 'mdata_exec_timeout', 'nics',
         'owner_uuid', 'quota', 'ram',
         'resolvers', 'vcpus', 'zfs_data_compression', 'zfs_io_priority',
-        'zfs_snapshot_limit', 'zlog_max_size', 'tags', 'tmpfs'
+        'zlog_max_size', 'tags', 'tmpfs'
     ];
 
     for (i = 0; i < keys.length; i++) {


### PR DESCRIPTION
This reverts commit 9a60713b7521175c1a6c9dab6ea017b1b76982f4.

Needs more work because "none" is a legitimate value in zfs(1M)...
... '' or undefined is a legitimate value in vmadm(1M)...
... and we need to have VMAPI accept "null" or undefined.