### PR TITLE
TRITON-2178 migration workflow doesn't properly pass package data

### DIFF
--- a/lib/apis/wfapi.js
+++ b/lib/apis/wfapi.js
@@ -794,7 +794,6 @@ Wfapi.prototype.createMigrateJob = function _createMigrateJobFn(req, cb) {
     assert.string(req.migrationTask.action, 'req.migrationTask.action');
     assert.optionalObject(req.migrationTask.record, 'req.migrationTask.record');
     assert.object(req.vm, 'req.vm');
-    assert.object(req.vm.package, 'req.vm.package');
     assert.string(req.vm.server_uuid, 'req.vm.server_uuid');
     assert.string(req.vm.uuid, 'req.vm.uuid');
     assert.optionalString(req.params.is_migration_subtask,
@@ -817,7 +816,6 @@ Wfapi.prototype.createMigrateJob = function _createMigrateJobFn(req, cb) {
         is_migration_subtask: Boolean(req.params.is_migration_subtask),
         migrationTask: req.migrationTask,
         override_alias: req.params.override_alias,
-        package: req.vm.package,
         server_uuid: req.vm.server_uuid, // Used by the acquireVMTicket calls.
         target: '/migrate-' + vm_uuid,
         zfs_send_mbps_limit: req.app.options.zfs_send_mbps_limit,
@@ -826,6 +824,11 @@ Wfapi.prototype.createMigrateJob = function _createMigrateJobFn(req, cb) {
         vm_uuid: vm_uuid,
         'x-request-id': req.getId()
     };
+
+    if (action === 'begin') {
+        assert.object(req.vm.package, 'req.vm.package');
+        params.package = req.vm.package;
+    }
 
     setContext(req, params);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmapi",
   "description": "VMs API",
-  "version": "9.10.1",
+  "version": "9.10.2",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Just noticed I made a whoopsie with my assert - as this code is called for all migrate actions (not just begin), but only the begin action will set the package details.