### PR TITLE
TRITON-2181 VMAPI changefeed needs to be updated to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmapi",
   "description": "VMs API",
-  "version": "9.10.2",
+  "version": "9.11.0",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {
@@ -9,7 +9,7 @@
     "async": "0.7.0",
     "backoff": "2.5.0",
     "bunyan": "1.8.12",
-    "changefeed": "1.3.0",
+    "changefeed": "1.5.2",
     "cueball": "2.2.7",
     "dashdash": "1.14.1",
     "deep-diff": "0.3.3",


### PR DESCRIPTION
The version in use everywhere else includes route versioning, while the previous version in VMAPI was using VMAPI server version, instead of internal changefeed versions. Therefore the 400 Bad Request while trying to get CloudAPI tests working.