### PR TITLE
TRITON-2185 VMAPI should consistently set VM tags to {} when empty

### DIFF
--- a/lib/common/vm-common.js
+++ b/lib/common/vm-common.js
@@ -196,7 +196,7 @@ function translateVm(obj, fullObject) {
         vm.image_uuid = obj.image_uuid;
     }
     // Consistently set VM tags to {} when empty:
-    if (vm.tags === undefined) {
+    if (!vm.tags) {
         vm.tags = {};
     }
 

--- a/lib/common/vm-common.js
+++ b/lib/common/vm-common.js
@@ -195,6 +195,10 @@ function translateVm(obj, fullObject) {
     } else {
         vm.image_uuid = obj.image_uuid;
     }
+    // Consistently set VM tags to {} when empty:
+    if (vm.tags === undefined) {
+        vm.tags = {};
+    }
 
     if (fullObject) {
         if (vm.ram === undefined && vm.max_physical_memory !== undefined) {
@@ -209,7 +213,7 @@ function translateVm(obj, fullObject) {
             if (vm[key] === undefined) {
                 var value;
                 if (key === 'customer_metadata' ||
-                    key === 'internal_metadata' || key === 'tags') {
+                    key === 'internal_metadata') {
                     value = {};
                 } else if (key === 'nics' || key === 'snapshots' ||
                     key === 'datasets') {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmapi",
   "description": "VMs API",
-  "version": "9.11.0",
+  "version": "9.12.0",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This is related to the multiple changefeed messages related to VM tags for machines w/o any tags: https://github.com/joyent/sdc-cloudapi/pull/68#discussion_r531736913