### PR TITLE
TRITON-2197 Migration abort should not error when the target server does not exist

### DIFF
--- a/lib/workflows/vm-migration/abort.js
+++ b/lib/workflows/vm-migration/abort.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
  */
 
 
@@ -90,6 +90,13 @@ function deleteTargetDniVm(job, cb) {
 
     cnapi.del(url, function _cnapiDelTargetDniVmCb(err, req, res, task) {
         if (err) {
+            if (err.statusCode === 404) {
+                // Server not found - okay that makes our job easier.
+                cb(null, 'OK - target server does not exist');
+                // Don't need to wait for the cnapi task - it does not exist.
+                job.params.skip_zone_action = true;
+                return;
+            }
             cb(err);
             return;
         }


### PR DESCRIPTION
This is based (depends) on TRITON-2196 work (I'll rebase before pushing).