### PR TITLE
TOOLS-2449 update jenkins agent images to a modern pkgsrc bootstrap

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@
  * Copyright 2020 Joyent, Inc.
  */
 
-@Library('jenkins-joylib@v1.0.4') _
+@Library('jenkins-joylib@v1.0.6') _
 
 pipeline {
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2020 Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
  */
 
 @Library('jenkins-joylib@v1.0.6') _


### PR DESCRIPTION
Similar to the recent change for binder, testing here was that we were able to select a jenkins-agent in the new IAD build environment, and that the build completed successfully.