### PR TITLE
Add support for creating the NAT zone on an encrypted CN

### DIFF
--- a/lib/workflows/fabric-common.js
+++ b/lib/workflows/fabric-common.js
@@ -231,6 +231,16 @@ function provisionFabricNats(job, cb) {
                     ticket: tick.ticket.uuid
                 }
             };
+            
+            /* If the request says to place the VM on an encrypted CN then also place the NAT
+             * zone on an encrypted CN. This is necessary when all CNs are encrypted. 
+             * If the user doesn't want the NAT zone on an encrypted CN then they can first create 
+             * a VM without encryption to get the NAT zone placed on an unencrypted CN then create
+             * another VM with encryption since the NAT zone will have already been created.
+             */
+            if (job.params.internal_metadata && job.params.internal_metadata.encrypted === true) {
+                instParams.params.internal_metadata.encrypted = true;
+            }
 
             sapi.createInstanceAsync(natSvc, instParams,
                     function _afterSapiProv(createErr, inst) {


### PR DESCRIPTION
Before this change, if all CNs are encrypted there was no way to provision any VMs on a fabric network because when you attempt to provision the first VM then the NAT zone creation fails because the `encrypted` property is not set and therefore all encrypted CNs are eliminated from the list of servers that the NAT zone can be placed on. So now if the `encrypted` parameter is in the request and set to `true` then the same value will be used for the NAT zone.