### PR TITLE
TRITON-2504 VMAPI should support reprovision for bhyve branded zones.

### DIFF
--- a/lib/endpoints/vms.js
+++ b/lib/endpoints/vms.js
@@ -7,6 +7,7 @@
 /*
  * Copyright 2021 Joyent, Inc.
  * Copyright 2024 MNX Cloud, Inc.
+ * Copyright 2025 Edgecast Cloud LLC.
  */
 
 /*
@@ -814,7 +815,8 @@ function reprovisionVm(req, res, next) {
     var error;
     var vm = req.vm;
 
-    if (['joyent', 'joyent-minimal', 'lx'].indexOf(vm.brand) === -1) {
+    var reprov_brands = ['joyent', 'joyent-minimal', 'lx', 'bhyve', 'builder'];
+    if (reprov_brands.indexOf(vm.brand) === -1) {
         next(new errors.BrandNotSupportedError(
             'VM \'brand\' does not support reprovision'));
         return;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "vmapi",
   "description": "VMs API",
-  "version": "9.16.0",
-  "author": "MNX Cloud (mnx.io)",
+  "version": "9.17.0",
+  "author": "Edgecast Cloud (edgecast.io)",
   "private": true,
   "dependencies": {
     "assert-plus": "1.0.0",
@@ -26,7 +26,7 @@
     "strsplit": "1.0.0",
     "trace-event": "1.3.0",
     "triton-metrics": "0.1.1",
-    "triton-tags": "1.4.0",
+    "triton-tags": "1.5.0",
     "uuid": "3.3.3",
     "vasync": "2.2.0",
     "verror": "1.10.0",


### PR DESCRIPTION
Claude's first inclination added some additional validation.
I'm inclined to keep this much simpler in which case Claude doesn't get credit for the final change.

We have lots of validation down in vmadm which is already exposed by CNAPI and tested to be working.
I think the right place for the type of validation sketched out in [d0bdaad](https://github.com/TritonDataCenter/sdc-vmapi/pull/98/commits/d0bdaadea0c696f30ca601368c2961e8d96c2514) is probably up in CLOUDAPI when we get to that point.