### PR TITLE
bump to 1.5.0 node-triton-tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vmapi",
   "description": "VMs API",
-  "version": "9.16.0",
+  "version": "9.16.1",
   "author": "MNX Cloud (mnx.io)",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "strsplit": "1.0.0",
     "trace-event": "1.3.0",
     "triton-metrics": "0.1.1",
-    "triton-tags": "1.4.0",
+    "triton-tags": "1.5.0",
     "uuid": "3.3.3",
     "vasync": "2.2.0",
     "verror": "1.10.0",


### PR DESCRIPTION
Addresses Issue 97 to support ipv4 assigned addresses.

https://github.com/TritonDataCenter/sdc-vmapi/issues/97

